### PR TITLE
Add libavdevice-dev dependency to Linux install instructions

### DIFF
--- a/docs/src/user-guide/installation.md
+++ b/docs/src/user-guide/installation.md
@@ -40,6 +40,7 @@ First, install the required dependencies:
 sudo apt-get install \
     ffmpeg \
     sox \
+    libavdevice-dev \
     libgirepository1.0-dev \
     gstreamer1.0-gtk3 \
     gstreamer1.0-libav \


### PR DESCRIPTION
I got an error when installing from source on Ubuntu 18.04: "The pkg-config package 'libavdevice' is required but it could not be found."

![screenshot from 2018-10-01 11-01-47](https://user-images.githubusercontent.com/153459/46301430-f2c57700-c56b-11e8-8bfa-0808193b373e.png)

I fixed it with:

```
sudo apt-get install libavdevice-dev
```