### PR TITLE
Undo/Redo support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,11 +36,12 @@ let
         (toggleLibraryProfiling
          (toggleBenchmark
           (pkgs.haskell.lib.dontHaddock (haskellPackages.callCabal2nix "komposition" ./. {}))));
+  mkdocs = import ./mkdocs.nix { inherit nixpkgs; };
 in
 { komposition = drv;
   komposition-shell = haskellPackages.shellFor {
     withHoogle = true;
     packages = p: [drv];
-    buildInputs = with pkgs; [ cabal-install ];
+    buildInputs = with pkgs; [ cabal-install mkdocs.packages  ];
   };
 }

--- a/docs/src/user-guide/concepts/commands.md
+++ b/docs/src/user-guide/concepts/commands.md
@@ -5,16 +5,18 @@ modify, the timeline and other views of the application. The following table
 lists some of the central commands you can issue, and their key bindings.
 Most commands can also be issued by using the top-level menu bar.
 
-| Command   | Mode                      | Key Binding                       | Description                                               |
-|-----------|---------------------------|-----------------------------------|-----------------------------------------------------------|
-| Help      | <em>All</em>              | <kbd>?</kbd>                      | Display key bindings help in the current mode             |
-| Split     | Timeline                  | <kbd>s</kbd>                      | Split the currently focused composition, if possible      |
-| Delete    | Timeline                  | <kbd>d</kbd>                      | Delete the currently focused composition                  |
-| Import    | Timeline                  | <kbd>i</kbd>                      | Start a new asset import                                  |
-| Render    | Timeline                  | <kbd>r</kbd>                      | Render the project to a video file                        |
-| Preview   | Timeline                  | <kbd>&lt;space&gt;</kbd>          | Preview the currently focused composition                 |
-| Exit      | Timeline                  | <kbd>q</kbd>                      | Exit the Komposition application                          |
-| Cancel    | Library, Import           | <kbd>q</kbd>                      | Cancel/exit the current mode                              |
+| Command   | Mode                      | Key Binding                           | Description                                               |
+|-----------|---------------------------|---------------------------------------|-----------------------------------------------------------|
+| Help      | <em>All</em>              | <kbd>?</kbd>                          | Display key bindings help in the current mode             |
+| Split     | Timeline                  | <kbd>s</kbd>                          | Split the currently focused composition, if possible      |
+| Delete    | Timeline                  | <kbd>d</kbd>                          | Delete the currently focused composition                  |
+| Import    | Timeline                  | <kbd>i</kbd>                          | Start a new asset import                                  |
+| Render    | Timeline                  | <kbd>r</kbd>                          | Render the project to a video file                        |
+| Preview   | Timeline                  | <kbd>Space</kbd>                      | Preview the currently focused composition                 |
+| Undo      | Timeline                  | <kbd>u</kbd>                          | Undo the last command                                     |
+| Redo      | Timeline                  | <kbd>Ctrl</kbd> + <kbd>r</kbd>        | Redo the last undone command                              |
+| Exit      | Timeline                  | <kbd>q</kbd>                          | Exit the Komposition application                          |
+| Cancel    | Library, Import           | <kbd>q</kbd>                          | Cancel/exit the current mode                              |
 
 There are more commands not listed in this table. Press <kbd>?</kbd> in
 Komposition to see the full listing.

--- a/komposition.cabal
+++ b/komposition.cabal
@@ -34,6 +34,7 @@ library
                       , Komposition.FFmpeg.Process
                       , Komposition.Focus
                       , Komposition.Focus.Parent
+                      , Komposition.History
                       , Komposition.Import.Audio
                       , Komposition.Import.Video
                       , Komposition.KeyMap

--- a/mkdocs.nix
+++ b/mkdocs.nix
@@ -1,0 +1,88 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+with (import <nixpkgs> {});
+
+let
+  livereload = python27Packages.buildPythonPackage {
+    name = "livereload-2.5.1";
+    src = fetchurl {
+      url = https://pypi.python.org/packages/e9/2e/c4972828cf526a2e5f5571d647fb2740df68f17e8084a9a1092f4d209f4c/livereload-2.5.1.tar.gz;
+      sha256 = "0b2yyfnpddmrwjfqsndidzchkf3l9jlgzfkwl8dplim9gq6y2ba2";
+    };
+
+    propagatedBuildInputs = with python27Packages; [ six tornado ];
+
+    meta = {
+      homepage = https://github.com/lepture/python-livereload;
+      description = "Python LiveReload is an awesome tool for web developers";
+      license = nixpkgs.stdenv.lib.bsd;
+    };
+  };
+
+  mkdocs = python27Packages.buildPythonApplication rec {
+    name="mkdocs-0.17.2";
+    src = fetchurl {
+      url = https://pypi.python.org/packages/27/0a/bb42cda3b298ffb4b30375b7538a4d57803ff8be418ee3e00460188c4332/mkdocs-0.17.2.tar.gz;
+      sha256 = "18d3m9iws5shlbg0yj5xwiy68bliiz70v32y5pa8wi274c36nssa";
+    };
+
+    propagatedBuildInputs = with python27Packages; [ tornado livereload click pyyaml markdown jinja2 ];
+
+    meta = {
+      homepage = http://www.mkdocs.org/;
+      description = "MkDocs is a fast, simple and downright gorgeous static site generator that’s geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.";
+      license = stdenv.lib.licenses.bsd;
+    };
+  };
+
+  pymdown-extensions = python27Packages.buildPythonPackage {
+    name = "pymdown-extensions-4.8";
+    src = fetchurl {
+      url = https://pypi.python.org/packages/f5/9f/74d8a85458e831f3b161956b30bc60d31c6a507ed72ac4f4cb2ca08d8042/pymdown-extensions-4.8.tar.gz;
+      sha256 = "1zvi8d44v758vbhi9fl5x5gqs098ajamilfz53jzid0v0fad88nj";
+    };
+
+    propagatedBuildInputs = with python27Packages; [ markdown ];
+    doCheck = false;
+
+    meta = {
+      homepage = https://github.com/facelessuser/pymdown-extensions;
+      description = "Extension pack for Python Markdown.";
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
+  mkdocs-material = python27Packages.buildPythonPackage {
+    name = "mkdocs-material-2.6.0";
+    src = fetchurl {
+      url = https://pypi.python.org/packages/e3/85/f42493d453d9b6f51912b818134a4a555c597807ba96b40eae12017ede35/mkdocs-material-2.6.0.tar.gz;
+      sha256 = "1xq5nkj0g6gg4lm8nhcwc30g9drq1i4p4pky8s5c0rfa1s9s7sla";
+    };
+
+    propagatedBuildInputs = with python27Packages; [ pymdown-extensions pygments mkdocs ];
+
+    meta = {
+      homepage = https://squidfunk.github.io/mkdocs-material/;
+      description = "A Material Design theme for MkDocs";
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
+  markdown-fenced-code-tabs = python27Packages.buildPythonPackage {
+    name = "markdown-fenced-code-tabs-0.2.0";
+    src = fetchurl {
+      url = https://pypi.python.org/packages/21/7a/0cee39060c5173cbd80930b720fb18f5cb788477c03214ccdef44ec91d85/markdown-fenced-code-tabs-0.2.0.tar.gz;
+      sha256 = "05k5v9wlxgghw2k18savznxc1xgg60gqz60mka4gnp8nsxpz99zs";
+    };
+
+    propagatedBuildInputs = with python27Packages; [ markdown ];
+
+    meta = {
+      homepage = https://github.com/yacir/markdown-fenced-code-tabs;
+      description = "Generates Bootstrap HTML Tabs for Consecutive Fenced Code Blocks";
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+in
+{
+  packages = [mkdocs (python27.withPackages (p: [ mkdocs mkdocs-material ]))];
+}

--- a/mkdocs.nix
+++ b/mkdocs.nix
@@ -1,3 +1,4 @@
+# Based off https://github.com/tathougies/beam/blob/master/shell.nix
 { nixpkgs ? import <nixpkgs> {} }:
 with (import <nixpkgs> {});
 

--- a/src/Komposition/Application.hs
+++ b/src/Komposition/Application.hs
@@ -22,6 +22,7 @@ import           Data.Row.Records
 
 import           Komposition.Focus
 import           Komposition.Project
+import           Komposition.History
 
 import           Komposition.Application.KeyMaps
 import           Komposition.Application.TimelineMode
@@ -33,4 +34,4 @@ komposition project' = do
   timelineMode #gui model
   where
     initialFocus = SequenceFocus 0 Nothing
-    model = TimelineModel project' initialFocus Nothing (ZoomLevel 1)
+    model = TimelineModel (initialise project') initialFocus Nothing (ZoomLevel 1)

--- a/src/Komposition/Application/KeyMaps.hs
+++ b/src/Komposition/Application/KeyMaps.hs
@@ -44,7 +44,6 @@ keymaps =
       , ([KeyLeft], Mapping (FocusCommand FocusLeft))
       , ([KeyRight], Mapping (FocusCommand FocusRight))
       , ([KeyChar 'i'], Mapping Import)
-      , ([KeyChar 'r'], Mapping Render)
       , ([KeySpace], Mapping Preview)
       , ([KeyChar 'p'], insertBindings LeftOf)
       , ([KeyChar 'P'], insertBindings LeftMost)
@@ -52,6 +51,8 @@ keymaps =
       , ([KeyChar 'A'], insertBindings RightMost)
       , ([KeyChar 'd'], Mapping Delete)
       , ([KeyChar 's'], Mapping Split)
+      , ([KeyChar 'u'], Mapping Undo)
+      , ([KeyModifier Ctrl, KeyChar 'r'], Mapping Redo)
       , ([KeyChar '?'], Mapping Help)
       , ([KeyChar 'q'], Mapping Exit)
       ]

--- a/src/Komposition/History.hs
+++ b/src/Komposition/History.hs
@@ -1,0 +1,32 @@
+module Komposition.History (History, initialise, current, edit, undo, redo) where
+
+import           Komposition.Prelude
+import           Komposition.Project
+
+-- | The complete 'History' of a 'Project' editing.
+data History = History
+    { past    :: [Project] -- ^ All previous versions of the 'Project'.
+    , current :: Project   -- ^ The current version of the 'Project'.
+    , future  :: [Project] -- ^ All future versions of the 'Project' (after a
+                           --   series of 'undo' operations).
+    } deriving (Eq, Show, Generic)
+
+-- | Create a 'History' comprising only the current version of the 'Project'.
+initialise :: Project -> History
+initialise p = History [] p []
+
+-- | Edit the 'Project', recording the previous version in the 'History'.
+edit :: (Project -> Project) -> History -> History
+edit f (History ps c _) = History (c:ps) (f c) []
+
+-- | Undo the previous 'edit', recording the current version as a possible
+-- future in the 'History'. Returns @Nothing@ if there is nothing to undo.
+undo :: History -> Maybe History
+undo (History []     _ _ ) = Nothing
+undo (History (p:ps) c fs) = Just $ History ps p (c:fs)
+
+-- | Redo the previously undone 'edit', recording the current version in the
+-- 'History'. Returns @Nothing@ if there is nothing to redo.
+redo :: History -> Maybe History
+redo (History _  _ []    ) = Nothing
+redo (History ps c (f:fs)) = Just $ History (c:ps) f fs

--- a/src/Komposition/History.hs
+++ b/src/Komposition/History.hs
@@ -1,32 +1,31 @@
 module Komposition.History (History, initialise, current, edit, undo, redo) where
 
 import           Komposition.Prelude
-import           Komposition.Project
 
--- | The complete 'History' of a 'Project' editing.
-data History = History
-    { past    :: [Project] -- ^ All previous versions of the 'Project'.
-    , current :: Project   -- ^ The current version of the 'Project'.
-    , future  :: [Project] -- ^ All future versions of the 'Project' (after a
+-- | The complete 'History' of 'a' values.
+data History a = History
+    { past    :: [a] -- ^ All previous versions of the 'a'.
+    , current :: a   -- ^ The current version of the 'a'.
+    , future  :: [a] -- ^ All future versions of the 'a' (after a
                            --   series of 'undo' operations).
-    } deriving (Eq, Show, Generic)
+    } deriving (Eq, Show)
 
--- | Create a 'History' comprising only the current version of the 'Project'.
-initialise :: Project -> History
-initialise p = History [] p []
+-- | Create a 'History' comprising only the current version of the 'a'.
+initialise :: a -> History a
+initialise x = History [] x []
 
--- | Edit the 'Project', recording the previous version in the 'History'.
-edit :: (Project -> Project) -> History -> History
+-- | Edit the 'a', recording the previous version in the 'History'.
+edit :: (a -> a) -> History a -> History a
 edit f (History ps c _) = History (c:ps) (f c) []
 
 -- | Undo the previous 'edit', recording the current version as a possible
 -- future in the 'History'. Returns @Nothing@ if there is nothing to undo.
-undo :: History -> Maybe History
+undo :: History a -> Maybe (History a)
 undo (History []     _ _ ) = Nothing
 undo (History (p:ps) c fs) = Just $ History ps p (c:fs)
 
 -- | Redo the previously undone 'edit', recording the current version in the
 -- 'History'. Returns @Nothing@ if there is nothing to redo.
-redo :: History -> Maybe History
+redo :: History a -> Maybe (History a)
 redo (History _  _ []    ) = Nothing
 redo (History ps c (f:fs)) = Just $ History (c:ps) f fs

--- a/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
@@ -235,7 +235,7 @@ timelineView model =
       True
       0
       (renderPreviewPane
-         (firstCompositionPart (model ^. currentFocus) (model ^. project . timeline)))
+         (firstCompositionPart (model ^. currentFocus) (currentProject model ^. timeline)))
     boxChild False False 0 $
       bin
         ScrolledWindow
@@ -248,5 +248,5 @@ timelineView model =
   where
     focusedTimelineWithSetFoci :: Timeline (Focus SequenceFocusType, Focused)
     focusedTimelineWithSetFoci =
-      withAllFoci (model ^. project . timeline) <&> \f ->
+      withAllFoci (currentProject model ^. timeline) <&> \f ->
         (f, focusedState (model ^. currentFocus) f)


### PR DESCRIPTION
This PR adds rudimentary undo and redo support, with the usual Vim bindings <kbd>u</kbd> and <kbd>Ctrl</kbd>-<kbd>r</kbd>, for undo and redo, respectively.