### PR TITLE
Add nix wrapper with GTK, Gnome, and GStreamer deps

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc843", doBenchmark ? false, doProfiling ? false }:
+{ compiler ? "ghc843", doCheck ? true, doBenchmark ? false, doProfiling ? false }:
 
 let
   nixpkgs = import (builtins.fetchGit {
@@ -28,6 +28,7 @@ let
         in self.callCabal2nix "gi-gtk-declarative" "${src}/gi-gtk-declarative" {};
     };
   };
+  toggleCheck = if doCheck then pkgs.haskell.lib.doCheck else pkgs.haskell.lib.dontCheck;
   toggleBenchmark = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
   toggleLibraryProfiling = if doBenchmark then pkgs.haskell.lib.enableLibraryProfiling else pkgs.haskell.lib.disableLibraryProfiling;
   toggleExecutableProfiling = if doBenchmark then pkgs.haskell.lib.enableExecutableProfiling else pkgs.haskell.lib.disableExecutableProfiling;
@@ -35,13 +36,57 @@ let
   drv = toggleExecutableProfiling
         (toggleLibraryProfiling
          (toggleBenchmark
-          (pkgs.haskell.lib.dontHaddock (haskellPackages.callCabal2nix "komposition" ./. {}))));
+          (toggleCheck
+           (pkgs.haskell.lib.dontHaddock (haskellPackages.callCabal2nix "komposition" ./. {})))));
   mkdocs = import ./mkdocs.nix { inherit nixpkgs; };
+
+  komposition = nixpkgs.stdenv.mkDerivation {
+    name = "komposition";
+    nativeBuildInputs = with nixpkgs; [ wrapGAppsHook makeWrapper ];
+    buildInputs = with nixpkgs; [
+      gnome3.gtk
+      gnome3.dconf
+      gnome3.defaultIconTheme
+      gnome3.gsettings_desktop_schemas
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      (gst_all_1.gst-plugins-good.override { gtkSupport = true; })
+      gst_all_1.gst-libav
+    ];
+    src = ./.;
+    buildPhase = ''
+        mkdir -p $out
+      '';
+    installPhase = ''
+      mkdir -p $out/bin
+      ln -s ${drv}/bin/komposition $out/bin
+      wrapProgram $out/bin/komposition \
+        --prefix 'PATH' ':' "${pkgs.ffmpeg}/bin" \
+        --prefix 'PATH' ':' "${pkgs.sox}/bin"
+    '';
+  };
 in
-{ komposition = drv;
+{ komposition = komposition;
   komposition-shell = haskellPackages.shellFor {
     withHoogle = true;
     packages = p: [drv];
-    buildInputs = with pkgs; [ cabal-install mkdocs.packages  ];
+    buildInputs = with pkgs; [
+      cabal-install
+      # Gnome/GTK+/Gstreamer
+      gnome3.gtk
+      gnome3.dconf
+      gnome3.defaultIconTheme
+      gnome3.gsettings_desktop_schemas
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      (gst_all_1.gst-plugins-good.override { gtkSupport = true; })
+      gst_all_1.gst-libav
+      # CLI tools
+      ffmpeg
+      sox
+      # Documentation
+      mkdocs.packages
+      ];
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc843", doCheck ? true, doBenchmark ? false, doProfiling ? false }:
+{ compiler ? "ghc843", doCheck ? true, doBenchmark ? false }:
 
 let
   nixpkgs = import (builtins.fetchGit {
@@ -30,14 +30,11 @@ let
   };
   toggleCheck = if doCheck then pkgs.haskell.lib.doCheck else pkgs.haskell.lib.dontCheck;
   toggleBenchmark = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
-  toggleLibraryProfiling = if doBenchmark then pkgs.haskell.lib.enableLibraryProfiling else pkgs.haskell.lib.disableLibraryProfiling;
-  toggleExecutableProfiling = if doBenchmark then pkgs.haskell.lib.enableExecutableProfiling else pkgs.haskell.lib.disableExecutableProfiling;
 
-  drv = toggleExecutableProfiling
-        (toggleLibraryProfiling
-         (toggleBenchmark
-          (toggleCheck
-           (pkgs.haskell.lib.dontHaddock (haskellPackages.callCabal2nix "komposition" ./. {})))));
+  drv = toggleBenchmark
+        (toggleCheck
+         (pkgs.haskell.lib.justStaticExecutables
+          (pkgs.haskell.lib.dontHaddock (haskellPackages.callCabal2nix "komposition" ./. {}))));
   mkdocs = import ./mkdocs.nix { inherit nixpkgs; };
 
   komposition = nixpkgs.stdenv.mkDerivation {

--- a/komposition.cabal
+++ b/komposition.cabal
@@ -7,7 +7,6 @@ description:          This project can be built using Stack, Cabal, and Nix. Ple
 stability:            alpha
 license:              MPL-2.0
 license-file:         LICENSE
-location:             git://github.com/owickstrom/komposition.git
 bug-reports:          https://github.com/owickstrom/komposition/issues
 author:               Oskar Wickström
 maintainer:           oskar.wickstrom@gmail.com
@@ -20,6 +19,10 @@ extra-source-files:   CHANGELOG.md
 data-dir:             src/data
 data-files:           style.css
                     , stripes.png
+
+source-repository head
+  type:               git
+  location:           git://github.com/owickstrom/komposition.git
 
 library
   exposed-modules:      Control.Monad.Indexed.IO


### PR DESCRIPTION
This can be tried out with:

```sh
$ cachix use komposition
$ nix-env -iA komposition -f https://github.com/owickstrom/komposition/archive/nix-deps.tar.gz
$ komposition
```