### PR TITLE
Open/save project support

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -2,35 +2,13 @@
 
 import           Komposition.Prelude
 
-import           System.IO.Temp
-
 import           Komposition.Application
-import           Komposition.Composition
 import           Komposition.Import.Video
-import           Komposition.Library
-import           Komposition.Project
 import           Komposition.UserInterface.GtkInterface
-import           Komposition.VideoSettings
 import           Paths_komposition
-
-initialProject :: FilePath -> IO Project
-initialProject workDir = do
-  return
-    Project
-    { _projectName = "Test"
-    , _timeline = emptyTimeline
-    , _library = Library [] []
-    , _workingDirectory = workDir
-    , _videoSettings =
-        VideoSettings {_frameRate = 25, _resolution = Resolution 1920 1080}
-    , _proxyVideoSettings =
-        VideoSettings {_frameRate = 25, _resolution = Resolution 960 540}
-    }
 
 main :: IO ()
 main = do
   initialize
   cssPath <- getDataFileName "style.css"
-  withSystemTempDirectory "project.komposition" $ \workDir -> do
-    p <- initialProject workDir
-    runGtkUserInterface cssPath (komposition p)
+  runGtkUserInterface cssPath komposition

--- a/komposition.cabal
+++ b/komposition.cabal
@@ -32,6 +32,7 @@ library
                       , Komposition.Application.KeyMaps
                       , Komposition.Application.LibraryMode
                       , Komposition.Application.TimelineMode
+                      , Komposition.Application.WelcomeScreenMode
                       , Komposition.Composition
                       , Komposition.Composition.Delete
                       , Komposition.Composition.Focused
@@ -62,6 +63,7 @@ library
                       , Komposition.UserInterface.GtkInterface.LibraryView
                       , Komposition.UserInterface.GtkInterface.TimelineView
                       , Komposition.UserInterface.GtkInterface.ThumbnailPreview
+                      , Komposition.UserInterface.GtkInterface.WelcomeScreenView
                       , Komposition.Timestamp
                       , Komposition.VideoSettings
   build-depends:        base >=4.10 && <4.12
@@ -160,12 +162,14 @@ test-suite komposition-tests
                  , Komposition.Composition.Generators
                  , Komposition.Composition.InsertTest
                  , Komposition.Composition.ValidFocusTest
-                 , Komposition.FocusTest
-                 , Komposition.Render.CompositionTest
-                 , Komposition.TimestampTest
                  , Komposition.FFmpeg.CommandTest
-                 , Komposition.TestLibrary
+                 , Komposition.FocusTest
                  , Komposition.Import.VideoTest
+                 , Komposition.Project.Generators
+                 , Komposition.Project.StoreTest
+                 , Komposition.Render.CompositionTest
+                 , Komposition.TestLibrary
+                 , Komposition.TimestampTest
   build-depends:   base                 >= 4        && < 5
                  , unordered-containers >= 0.2      && < 0.3
                  , extra
@@ -182,6 +186,7 @@ test-suite komposition-tests
                  , tasty-hspec
                  , tasty-hedgehog
                  , tasty-discover
+                 , temporary
   default-language:     Haskell2010
   default-extensions:   NoImplicitPrelude
   ghc-options:     -Wall -fno-warn-unticked-promoted-constructors

--- a/src/Komposition/Application.hs
+++ b/src/Komposition/Application.hs
@@ -20,18 +20,11 @@ import           Komposition.Application.Base
 
 import           Data.Row.Records
 
-import           Komposition.Focus
-import           Komposition.Project
-import           Komposition.History
-
 import           Komposition.Application.KeyMaps
-import           Komposition.Application.TimelineMode
+import           Komposition.Application.WelcomeScreenMode
 
 komposition
-  :: Application t m => UserInterface (t m) => Project -> t m Empty Empty ()
-komposition project' = do
-  start #gui (fmap CommandKeyMappedEvent . keymaps) model
-  timelineMode #gui model
-  where
-    initialFocus = SequenceFocus 0 Nothing
-    model = TimelineModel (initialise project') initialFocus Nothing (ZoomLevel 1)
+  :: Application t m => UserInterface (t m) => t m Empty Empty ()
+komposition = do
+  start #gui (fmap CommandKeyMappedEvent . keymaps)
+  welcomeScreenMode #gui

--- a/src/Komposition/Application/ImportMode.hs
+++ b/src/Komposition/Application/ImportMode.hs
@@ -83,13 +83,13 @@ importAsset gui timelineModel (filepath, autoSplit)
               importVideoFileAutoSplit
                 (currentProject timelineModel ^. proxyVideoSettings)
                 filepath
-                (currentProject timelineModel ^. workingDirectory)
+                (timelineModel ^. existingProject . projectPath . unProjectPath)
             False ->
               (: []) <$>
               importVideoFile
                 (currentProject timelineModel ^. proxyVideoSettings)
                 filepath
-                (currentProject timelineModel ^. workingDirectory)
+                (timelineModel ^. existingProject . projectPath . unProjectPath)
     in progressBar gui "Importing Video" action >>>= \case
          Nothing -> do
            ireturn timelineModel
@@ -101,12 +101,12 @@ importAsset gui timelineModel (filepath, autoSplit)
             True ->
               importAudioFileAutoSplit
                 filepath
-                (currentProject timelineModel ^. workingDirectory)
+                (timelineModel ^. existingProject . projectPath . unProjectPath)
             False ->
               (: []) <$>
               importAudioFile
                 filepath
-                (currentProject timelineModel ^. workingDirectory)
+                (timelineModel ^. existingProject . projectPath . unProjectPath)
     in progressBar gui "Importing Audio" action >>>= \case
       Nothing -> ireturn timelineModel
       Just (assets :: Either AudioImportError [AudioAsset]) ->
@@ -134,9 +134,9 @@ handleImportResult gui model mediaType result = case (mediaType, result) of
     ireturn model
   (SVideo, Right assets) ->
     model
-      & projectHistory %~ edit (library . videoAssets %~ (<> assets))
+      & existingProject . projectHistory %~ edit (library . videoAssets %~ (<> assets))
       & ireturn
   (SAudio, Right assets) ->
     model
-      & projectHistory %~ edit (library . audioAssets %~ (<> assets))
+      & existingProject . projectHistory %~ edit (library . audioAssets %~ (<> assets))
       & ireturn

--- a/src/Komposition/Application/KeyMaps.hs
+++ b/src/Komposition/Application/KeyMaps.hs
@@ -34,6 +34,11 @@ insertBindings position =
 keymaps :: SMode m -> KeyMap (Command m)
 keymaps =
   \case
+    SWelcomeScreenMode ->
+      [ ([KeyChar 'q'], Mapping Cancel)
+      , ([KeyEscape], Mapping Cancel)
+      , ([KeyChar '?'], Mapping Help)
+      ]
     STimelineMode ->
       [ ([KeyChar 'h'], Mapping (FocusCommand FocusLeft))
       , ([KeyChar 'j'], Mapping (FocusCommand FocusDown))

--- a/src/Komposition/Application/LibraryMode.hs
+++ b/src/Komposition/Application/LibraryMode.hs
@@ -95,7 +95,7 @@ selectAssetAndInsert gui model mediaType' position =
     Just assets -> do
       i <- insertionOf assets
       model
-        & projectHistory %~ (edit (\p -> p & timeline %~ insert_ (model ^. currentFocus) i position))
+        & existingProject . projectHistory %~ edit (\p -> p & timeline %~ insert_ (model ^. currentFocus) i position)
         & ireturn
     Nothing -> do
       beep gui
@@ -119,7 +119,7 @@ selectAssetAndInsert gui model mediaType' position =
            VideoProxy
            videoAsset
            ts
-           (currentProject model ^. workingDirectory)
+           (model ^. existingProject . projectPath . unProjectPath)
 
 noAssetsMessage :: SMediaType mt -> Text
 noAssetsMessage mt =

--- a/src/Komposition/Application/LibraryMode.hs
+++ b/src/Komposition/Application/LibraryMode.hs
@@ -11,20 +11,10 @@ module Komposition.Application.LibraryMode where
 
 import           Komposition.Application.Base
 
-import           Control.Lens
-import qualified Data.List.NonEmpty          as NonEmpty
 import           Data.Row.Records
-import           Data.String                 (fromString)
 
-import           Komposition.Composition
-import           Komposition.Composition.Insert
-import           Komposition.Duration
-import           Komposition.History
 import           Komposition.Library
 import           Komposition.MediaType
-import           Komposition.Project
-import qualified Komposition.Render.Composition  as Composition
-import           Komposition.Render.FFmpeg
 
 import           Komposition.Application.KeyMaps
 
@@ -58,73 +48,52 @@ selectAssetFromList gui model = do
     continueWith = selectAssetFromList gui
 
 selectAsset ::
-     (Application t m, r ~ (n .== State (t m) 'TimelineMode))
+     ( Application t m
+     )
   => Name n
-  -> TimelineModel
-  -> SMediaType mt
-  -> t m r r (Maybe [Asset mt])
-selectAsset gui model = \case
-  SVideo ->
-    case NonEmpty.nonEmpty (currentProject model ^. library . videoAssets) of
-      Just vs -> do
-        let libraryModel = SelectAssetsModel SVideo vs []
-        enterLibrary gui libraryModel
-        assets <- selectAssetFromList gui libraryModel
-        returnToTimeline gui model
-        ireturn assets
-      Nothing -> ireturn Nothing
-  SAudio ->
-    case NonEmpty.nonEmpty (currentProject model ^. library . audioAssets) of
-      Just as -> do
-        let libraryModel = SelectAssetsModel SAudio as []
-        enterLibrary gui libraryModel
-        assets <- selectAssetFromList gui libraryModel
-        returnToTimeline gui model
-        ireturn assets
-      Nothing -> ireturn Nothing
+  -> SelectAssetsModel mt
+  -> ThroughMode TimelineMode LibraryMode (t m) n (Maybe [Asset mt])
+selectAsset gui libraryModel returnToOrigin = do
+  enterLibrary gui libraryModel
+  selectAssetFromList gui libraryModel >>>= returnToOrigin
 
-selectAssetAndInsert ::
-     (Application t m, r ~ (n .== State (t m) 'TimelineMode))
-  => Name n
-  -> TimelineModel
-  -> SMediaType mt
-  -> InsertPosition
-  -> t m r r TimelineModel
-selectAssetAndInsert gui model mediaType' position =
-  selectAsset gui model mediaType' >>= \case
-    Just assets -> do
-      i <- insertionOf assets
-      model
-        & existingProject . projectHistory %~ edit (\p -> p & timeline %~ insert_ (model ^. currentFocus) i position)
-        & ireturn
-    Nothing -> do
-      beep gui
-      ireturn (model & statusMessage .~ Just (noAssetsMessage mediaType'))
-  where
-    insertionOf a =
-      case mediaType' of
-        SVideo -> iliftIO (InsertVideoParts <$> mapM toVideoClip a)
-        SAudio -> ireturn (InsertAudioParts (AudioClip () <$> a))
-    toVideoClip :: VideoAsset -> IO (VideoPart ())
-    toVideoClip videoAsset =
-      let ts =
-            maybe
-              (TimeSpan 0 (durationOf videoAsset))
-              snd
-              (videoAsset ^. videoClassifiedScene)
-      in VideoClip () videoAsset ts <$>
-         extractFrameToFile
-           (currentProject model ^. videoSettings)
-           Composition.FirstFrame
-           VideoProxy
-           videoAsset
-           ts
-           (model ^. existingProject . projectPath . unProjectPath)
 
-noAssetsMessage :: SMediaType mt -> Text
-noAssetsMessage mt =
-  "You have no " <> mt' <> " assets in your library. Use 'Import' to add some assets."
-  where
-    mt' = case mt of
-      SVideo -> "video"
-      SAudio -> "audio"
+
+
+-- selectAssetAndInsert ::
+--      (Application t m, r ~ (n .== State (t m) 'TimelineMode))
+--   => Name n
+--   -> TimelineModel
+--   -> SMediaType mt
+--   -> InsertPosition
+--   -> ThroughMode TimelineMode LibraryMode (t m) n (Maybe [Asset mt])
+-- selectAssetAndInsert gui model mediaType' position =
+--   selectAsset gui model mediaType' >>= \case
+--     Just assets -> do
+--       i <- insertionOf assets
+--       model
+--         & existingProject . projectHistory %~ edit (\p -> p & timeline %~ insert_ (model ^. currentFocus) i position)
+--         & ireturn
+--     Nothing -> do
+--       beep gui
+--       ireturn (model & statusMessage .~ Just (noAssetsMessage mediaType'))
+--   where
+--     insertionOf a =
+--       case mediaType' of
+--         SVideo -> iliftIO (InsertVideoParts <$> mapM toVideoClip a)
+--         SAudio -> ireturn (InsertAudioParts (AudioClip () <$> a))
+--     toVideoClip :: VideoAsset -> IO (VideoPart ())
+--     toVideoClip videoAsset =
+--       let ts =
+--             maybe
+--               (TimeSpan 0 (durationOf videoAsset))
+--               snd
+--               (videoAsset ^. videoClassifiedScene)
+--       in VideoClip () videoAsset ts <$>
+--          extractFrameToFile
+--            (currentProject model ^. videoSettings)
+--            Composition.FirstFrame
+--            VideoProxy
+--            videoAsset
+--            ts
+--            (model ^. existingProject . projectPath . unProjectPath)

--- a/src/Komposition/Application/TimelineMode.hs
+++ b/src/Komposition/Application/TimelineMode.hs
@@ -59,7 +59,7 @@ timelineMode gui model = do
     continue = timelineMode gui model
     continueWithStatusMessage msg =
       model
-      & statusMessage .~ Just msg
+      & statusMessage ?~ msg
       & timelineMode gui
     resetStatusMessage =
       model
@@ -117,7 +117,7 @@ timelineMode gui model = do
           Just flat -> do
             outDir <- iliftIO getUserDocumentsDirectory
             chooseFile gui (Save File) "Render To File" outDir >>>= \case
-              Just outFile -> do
+              Just outFile ->
                 progressBar
                   gui
                   "Rendering"
@@ -144,7 +144,7 @@ timelineMode gui model = do
         case model & existingProject . projectHistory %%~ redo of
           Just m  -> timelineMode gui m
           Nothing -> beep gui >> timelineMode gui model
-      CommandKeyMappedEvent SaveProject -> do
+      CommandKeyMappedEvent SaveProject ->
         iliftIO (saveExistingProject (model ^. existingProject)) >>= \case
           _ -> continue
       CommandKeyMappedEvent CloseProject -> ireturn TimelineClose
@@ -197,7 +197,7 @@ insertIntoTimeline gui model type' position =
       insertGap gui model SAudio position >>>= timelineMode gui
     (c, Just f) -> do
       let msg = "Cannot perform " <> show c <> " when focused at " <> prettyFocusedAt f
-      timelineMode gui (model & statusMessage .~ Just msg)
+      timelineMode gui (model & statusMessage ?~ msg)
     (_, Nothing) -> do
       iliftIO (putStrLn ("Warning: focus is invalid." :: Text))
       continue
@@ -262,11 +262,11 @@ previewFocusedComposition gui model =
     Nothing -> do
       beep gui
       model
-        & statusMessage .~ Just "Cannot preview a composition without video clips."
+        & statusMessage ?~ "Cannot preview a composition without video clips."
         & ireturn
   where
     flatComposition :: Maybe Render.Composition
-    flatComposition = do
+    flatComposition =
       atFocus (model ^. currentFocus) (currentProject model ^. timeline) Prelude.>>= \case
         FocusedSequence s -> Render.flattenSequence s
         FocusedParallel p -> Render.flattenParallel p
@@ -322,7 +322,7 @@ insertSelectedAssets gui model mediaType' position result = do
         Nothing -> do
           beep gui
           model
-            & statusMessage .~ Just (noAssetsMessage mediaType')
+            & statusMessage ?~ noAssetsMessage mediaType'
             & ireturn
   returnToTimeline gui model'
   timelineMode gui model'

--- a/src/Komposition/Application/WelcomeScreenMode.hs
+++ b/src/Komposition/Application/WelcomeScreenMode.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RebindableSyntax    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+module Komposition.Application.WelcomeScreenMode where
+
+import           Komposition.Application.Base
+
+import           Data.Row.Records                     hiding (split)
+import           Data.String                          (fromString)
+import           System.Directory
+
+import           Komposition.Composition
+import           Komposition.Focus
+import           Komposition.Library
+import           Komposition.Project
+import           Komposition.Project.Store
+import           Komposition.VideoSettings
+
+import           Komposition.Application.KeyMaps
+import           Komposition.Application.TimelineMode
+
+welcomeScreenMode
+  :: Application t m
+  => Name n
+  -> t m (n .== State (t m) WelcomeScreenMode) Empty ()
+welcomeScreenMode gui = do
+  updateWelcomeScreen gui
+  nextEvent gui >>= \case
+    OpenExistingProjectClicked -> do
+      userDir <- iliftIO getUserDocumentsDirectory
+      chooseFile gui (Open Directory) "Open Project Directory" userDir >>= \case
+        Just path' -> do
+          iliftIO (openExistingProject path') >>= \case
+            Left err -> do
+              iliftIO (putStrLn ("Opening existing project failed: " <> show err :: Text))
+              welcomeScreenMode gui
+            Right existingProject' -> toTimelineWithProject gui existingProject'
+        Nothing -> welcomeScreenMode gui
+    CreateNewProjectClicked -> do
+      userDir <- iliftIO getUserDocumentsDirectory
+      chooseFile gui (Save Directory) "Choose Project Directory" userDir >>= \case
+        Just path' ->
+          iliftIO (createNewProject path' initialProject) >>= \case
+            Left err -> do
+              beep gui
+              iliftIO (putStrLn ("Create new project failed: " <> show err :: Text))
+              welcomeScreenMode gui
+            Right newProject -> toTimelineWithProject gui newProject
+        Nothing -> welcomeScreenMode gui
+    CommandKeyMappedEvent Cancel -> exit gui
+    CommandKeyMappedEvent Help -> do
+      help gui [ModeKeyMap STimelineMode (keymaps STimelineMode)]
+      welcomeScreenMode gui
+
+toTimelineWithProject
+  :: Application t m
+  => Name n
+  -> ExistingProject
+  -> t m (n .== State (t m) 'WelcomeScreenMode) Empty ()
+toTimelineWithProject gui project = do
+  let model = TimelineModel project initialFocus Nothing (ZoomLevel 1)
+  returnToTimeline gui model
+  timelineMode gui model
+
+initialProject :: Project
+initialProject =
+  Project
+    { _projectName = "Test"
+    , _timeline = emptyTimeline
+    , _library = Library [] []
+    , _videoSettings =
+        VideoSettings {_frameRate = 25, _resolution = Resolution 1920 1080}
+    , _proxyVideoSettings =
+        VideoSettings {_frameRate = 25, _resolution = Resolution 960 540}
+    }
+
+initialFocus :: Focus SequenceFocusType
+initialFocus = SequenceFocus 0 Nothing

--- a/src/Komposition/Application/WelcomeScreenMode.hs
+++ b/src/Komposition/Application/WelcomeScreenMode.hs
@@ -68,7 +68,26 @@ toTimelineWithProject
 toTimelineWithProject gui project = do
   let model = TimelineModel project initialFocus Nothing (ZoomLevel 1)
   returnToTimeline gui model
-  timelineMode gui model
+  runTimeline model
+  where
+    runTimeline model =
+      timelineMode gui model >>= \case
+        TimelineExit ->
+          dialog gui "Confirm Exit" "Are you sure you want to exit?" [No, Yes] >>>= \case
+            Just Yes -> exit gui
+            Just No -> runTimeline model
+            Nothing -> runTimeline model
+        TimelineClose -> returnToWelcomeScreen gui >>> welcomeScreenMode gui
+
+data Confirmation
+  = Yes
+  | No
+  deriving (Show, Eq, Enum)
+
+instance DialogChoice Confirmation where
+  toButtonLabel = \case
+    Yes -> "Yes"
+    No -> "No"
 
 initialProject :: Project
 initialProject =

--- a/src/Komposition/History.hs
+++ b/src/Komposition/History.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Komposition.History (History, initialise, current, edit, undo, redo) where
 
 import           Komposition.Prelude
@@ -8,7 +9,7 @@ data History a = History
     , current :: a   -- ^ The current version of the 'a'.
     , future  :: [a] -- ^ All future versions of the 'a' (after a
                            --   series of 'undo' operations).
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | Create a 'History' comprising only the current version of the 'a'.
 initialise :: a -> History a

--- a/src/Komposition/Project.hs
+++ b/src/Komposition/Project.hs
@@ -12,8 +12,9 @@ module Komposition.Project where
 import           Komposition.Prelude
 
 import           Control.Lens
-import           Data.Text             (Text)
+import           Data.Text                 (Text)
 
+import           Komposition.History
 import           Komposition.Composition
 import           Komposition.Library
 import           Komposition.VideoSettings
@@ -22,9 +23,20 @@ data Project = Project
   { _projectName        :: Text
   , _timeline           :: Timeline ()
   , _library            :: Library
-  , _workingDirectory   :: FilePath
   , _videoSettings      :: VideoSettings
   , _proxyVideoSettings :: VideoSettings
   } deriving (Eq, Show, Generic)
 
 makeLenses ''Project
+
+newtype ProjectPath = ProjectPath { _unProjectPath :: FilePath }
+   deriving (Eq, Show, Generic)
+
+makeLenses ''ProjectPath
+
+data ExistingProject = ExistingProject
+  { _projectPath :: ProjectPath
+  , _projectHistory :: History Project
+  } deriving (Eq, Show)
+
+makeLenses ''ExistingProject

--- a/src/Komposition/Project/Store.hs
+++ b/src/Komposition/Project/Store.hs
@@ -1,19 +1,27 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Komposition.Project.Store
-  ( readProjectFile
-  , writeProjectFile
+  ( createNewProject
+  , saveExistingProject
+  , SaveProjectError(..)
+  , openExistingProject
+  , OpenProjectError(..)
   ) where
 
 import           Komposition.Prelude       hiding (Type, list)
 
-import           Data.Binary           (Binary)
-import qualified Data.Binary           as Binary
-import           Data.Time.Clock       (diffTimeToPicoseconds,
-                                        picosecondsToDiffTime)
+import           Control.Lens
+import           Data.Binary               (Binary)
+import qualified Data.Binary               as Binary
+import           Data.Time.Clock           (diffTimeToPicoseconds,
+                                            picosecondsToDiffTime)
+import           System.Directory
+import           System.FilePath
 
 import           Komposition.Composition
 import           Komposition.Duration
+import           Komposition.History
 import           Komposition.Library
 import           Komposition.Project
 import           Komposition.VideoSettings
@@ -40,8 +48,62 @@ instance Binary Resolution
 instance Binary VideoSettings
 instance Binary Project
 
-readProjectFile :: FilePath -> IO Project
-readProjectFile = Binary.decodeFile
+instance Binary a => Binary (History a)
 
-writeProjectFile :: FilePath -> Project -> IO ()
-writeProjectFile = Binary.encodeFile
+data SaveProjectError
+  = ProjectDirectoryNotEmpty FilePath
+  | UnexpectedSaveError Text
+  deriving (Eq, Show)
+
+createNewProject :: FilePath -> Project -> IO (Either SaveProjectError ExistingProject)
+createNewProject targetPath newProject = runExceptT $ do
+  whenM (liftIO (not . null <$> listDirectory targetPath)) $
+    throwError (ProjectDirectoryNotEmpty targetPath)
+  liftIO (createDirectoryIfMissing False targetPath)
+  let existingProject =  ExistingProject (ProjectPath targetPath) (initialise newProject)
+  writeProject existingProject
+    `catchE` (\(e :: SomeException) -> throwError (UnexpectedSaveError (show e)))
+  return existingProject
+
+saveExistingProject :: ExistingProject -> IO (Either SaveProjectError ())
+saveExistingProject existingProject = runExceptT $
+  writeProject existingProject
+    `catchE` (\(e :: SomeException) -> throwError (UnexpectedSaveError (show e)))
+
+data OpenProjectError
+  = ProjectDirectoryDoesNotExist FilePath
+  | ProjectDataFileDoesNotExist FilePath
+  | InvalidProjectDirectory FilePath
+  | InvalidProjectDataFile FilePath
+  deriving (Eq, Show)
+
+openExistingProject :: FilePath -> IO (Either OpenProjectError ExistingProject)
+openExistingProject path' = runExceptT $ do
+  whenM (liftIO (not <$> doesPathExist path')) $
+    throwError (ProjectDirectoryDoesNotExist path')
+  let projectPath' = (ProjectPath path')
+      dataFilePath = projectDataFilePath projectPath'
+  whenM (liftIO (not <$> doesPathExist dataFilePath)) $
+    throwError (ProjectDataFileDoesNotExist dataFilePath)
+  existingHistory <- liftIO (readProjectDataFile dataFilePath)
+    `catchE` (\(e :: SomeException) -> do
+      putStrLn ("Invalid project data file: " <> show e)
+      throwError (InvalidProjectDataFile dataFilePath))
+  return (ExistingProject projectPath' existingHistory)
+
+projectDataFilePath :: ProjectPath -> FilePath
+projectDataFilePath p =
+  p ^. unProjectPath </> "project-history.bin"
+
+writeProject :: ExistingProject -> ExceptT e IO ()
+writeProject existingProject =
+  liftIO $
+    writeProjectDataFile
+      (projectDataFilePath (existingProject ^. projectPath))
+      (existingProject ^. projectHistory)
+
+readProjectDataFile :: FilePath -> IO (History Project)
+readProjectDataFile = Binary.decodeFile
+
+writeProjectDataFile :: FilePath -> History Project -> IO ()
+writeProjectDataFile = Binary.encodeFile

--- a/src/Komposition/UserInterface/GtkInterface.hs
+++ b/src/Komposition/UserInterface/GtkInterface.hs
@@ -345,6 +345,9 @@ instance (MonadReader Env m, MonadIO m) => UserInterface (GtkInterface m) where
   updateWelcomeScreen n =
     switchView' n (TopView welcomeScreenView) SWelcomeScreenMode
 
+  returnToWelcomeScreen n =
+    switchView' n (TopView welcomeScreenView) SWelcomeScreenMode
+
   updateTimeline n model =
     switchView' n (TopView (timelineView model)) STimelineMode
 

--- a/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
@@ -177,6 +177,7 @@ renderMenu =
   container MenuBar [] $ do
     subMenu "Project" $ do
       labelledItem SaveProject
+      labelledItem CloseProject
       labelledItem Import
       labelledItem Render
       labelledItem Exit

--- a/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
@@ -176,6 +176,7 @@ renderMenu :: Widget (Event TimelineMode)
 renderMenu =
   container MenuBar [] $ do
     subMenu "Project" $ do
+      labelledItem SaveProject
       labelledItem Import
       labelledItem Render
       labelledItem Exit

--- a/src/Komposition/UserInterface/GtkInterface/WelcomeScreenView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/WelcomeScreenView.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE ExplicitForAll    #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedLabels  #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Komposition.UserInterface.GtkInterface.WelcomeScreenView
+  ( welcomeScreenView
+  ) where
+
+import           Komposition.Prelude       hiding (on)
+
+import           GI.Gtk                    (Box (..), Button (..), Label (..),
+                                            Orientation (..))
+import           GI.Gtk.Declarative
+
+import           Komposition.UserInterface
+
+welcomeScreenView :: Widget (Event WelcomeScreenMode)
+welcomeScreenView =
+  container Box [ #orientation := OrientationVertical
+                , classes ["welcome-screen"]
+                , #widthRequest := 400
+                , #heightRequest := 300
+                ] $ do
+    boxChild False False 0 $ do
+      widget Label [ classes ["title"], #label := "Komposition"]
+    boxChild False False 0 $ do
+      widget Label [ classes ["subtitle"], #label := "The video editor built for screencasters"]
+    boxChild False False 0 $ do
+      container Box [#orientation := OrientationVertical, classes ["actions"]] $ do
+        boxChild False False 0 $
+          widget Button [#label := "Create New Project", on #clicked CreateNewProjectClicked]
+        boxChild False False 0 $
+          widget Button [#label := "Open Existing Project", on #clicked OpenExistingProjectClicked]

--- a/src/data/style.css
+++ b/src/data/style.css
@@ -136,3 +136,19 @@
 .zoom-level {
   min-width: 5em;
 }
+
+.welcome-screen .title {
+  margin: 2em 0 .5em;
+  font-weight: bold;
+  font-size: 175%;
+}
+.welcome-screen .subtitle {
+  margin-bottom: 1em;
+  font-size: 125%;
+}
+.welcome-screen .actions {
+  padding: 2em;
+}
+.welcome-screen .actions button {
+  margin: .5em 0;
+}

--- a/test/Komposition/Project/Generators.hs
+++ b/test/Komposition/Project/Generators.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Komposition.Project.Generators where
+
+import           Komposition.Prelude                   hiding ( nonEmpty )
+
+import           Hedgehog
+import qualified Hedgehog.Gen                  as Gen hiding (parallel)
+import           Hedgehog.Range
+
+import           Komposition.Project (Project(..))
+import           Komposition.Library
+import           Komposition.VideoSettings (VideoSettings(..), Resolution(..))
+import qualified Komposition.Composition.Generators as Gen
+
+library :: MonadGen m => m Library
+library =
+    Library
+    <$> Gen.list (linear 1 5) Gen.videoAsset
+    <*> Gen.list (linear 1 5) Gen.audioAsset
+
+resolution :: MonadGen m => m Resolution
+resolution =
+  Resolution
+  <$> Gen.word (linear 200 2000)
+  <*> Gen.word (linear 200 2000)
+
+videoSettings :: MonadGen m => m VideoSettings
+videoSettings =
+  VideoSettings <$> Gen.word (linear 15 25) <*> resolution
+
+project :: MonadGen m => m Project
+project = do
+  _projectName <- Gen.text (linear 1 5) Gen.unicode
+  _timeline <- Gen.timeline (linear 1 10) Gen.parallel
+  _library <- library
+  _videoSettings <- videoSettings
+  _proxyVideoSettings <- videoSettings
+  return Project{..}

--- a/test/Komposition/Project/StoreTest.hs
+++ b/test/Komposition/Project/StoreTest.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module Komposition.Project.StoreTest where
+
+import           Komposition.Prelude
+import qualified Prelude
+
+import           Control.Lens
+import           Hedgehog                       hiding (Parallel)
+import System.IO.Temp
+
+import qualified Komposition.Project.Generators as Gen
+import           Komposition.Project.Store
+import           Komposition.History
+import           Komposition.Project
+
+hprop_createAndOpenNewProject =
+  withTests 100 $ property $ do
+    newProject <- forAll Gen.project
+    tmpRoot <- liftIO getCanonicalTemporaryDirectory
+    path <- liftIO $ createTempDirectory tmpRoot "project-store-test"
+    existing <- create path newProject
+    loaded <- open path
+    existing === loaded
+
+hprop_createAndSaveNewProject =
+  withTests 100 $ property $ do
+    (newProject, modifiedProject) <- forAll ((,) <$> Gen.project <*> Gen.project)
+    tmpRoot <- liftIO getCanonicalTemporaryDirectory
+    path <- liftIO $ createTempDirectory tmpRoot "project-store-test"
+    initialExisting <- create path newProject
+    let existingModified = initialExisting & projectHistory %~ edit (const modifiedProject)
+    _ <- save existingModified
+    loaded <- open path
+    loaded === existingModified
+    undoneExisting <-
+      maybe failure pure (existingModified & projectHistory %%~ undo)
+    current (undoneExisting ^. projectHistory) === current (initialExisting ^. projectHistory)
+
+create path newProject =
+  liftIO (createNewProject path newProject) >>= \case
+    Left err -> footnoteShow err >> failure
+    Right existing -> return existing
+
+open path =
+  liftIO (openExistingProject path) >>= \case
+    Left err -> footnoteShow err >> failure
+    Right loaded -> return loaded
+
+save existing =
+  liftIO (saveExistingProject existing) >>= \case
+    Left err -> footnoteShow err >> failure
+    Right () -> return ()
+
+{-# ANN module ("HLint: ignore Use camelCase" :: Prelude.String) #-}


### PR DESCRIPTION
This adds support for creating new projects, saving existing projects, and opening existing projects.

It adds a welcome screen that gives you two options:

* create a new project, or
* open an existing one.

When a project is opened or created, it switches to timeline mode. This means that in timeline mode there is always an existing project.