### PR TITLE
Fix dash encoding

### DIFF
--- a/src/Komposition/Import/Audio.hs
+++ b/src/Komposition/Import/Audio.hs
@@ -89,8 +89,8 @@ normalizeAudio tempDir sourcePath = do
     , outPath
     , "compand"
     , ".1,.2"
-    , "−inf,−50.1,−inf,−50,−50", "0"
-    , "−90"
+    , "-inf,-50.1,-inf,-50,-50", "0"
+    , "-90"
     , ".1"
     ]
   return outPath
@@ -200,7 +200,7 @@ getAudioFileMaxAmplitude inPath = do
          readDouble ampStr
     ExitFailure c -> throwIO (ProcessFailed "sox" c (Just (toS err)))
 
-transcodeAudioFileToWav 
+transcodeAudioFileToWav
   :: (MonadIO m, MonadSafe m)
   => FilePath
   -> Duration


### PR DESCRIPTION
When running this on my machine (Ubuntu 18) importing the audio would constantly fail, after some adding some logging in the audio function it seemed the arguments to `sox` were being passed through like so:

```
["--norm"
,"/tmp/komposition.audio.import-b12ab7b3f2e71edc/Arrows.wav"
,"/tmp/komposition.audio.import-b12ab7b3f2e71edc/preprocessed.wav"
,"compand"
,".1,.2"
,"\8722inf,\8722\&50.1,\8722inf,\8722\&50,\8722\&50"
,"0"
,"\8722\&90"
,".1"
]
```

Seemed as if there was something wrong with the dash characters, and it seems this is the case as replacing them fixes my issue around audio import. Logging now shows this:

```
["--norm"
,"/tmp/komposition.audio.import-3f6734d95ce3b8e4/Arrows.wav"
,"/tmp/komposition.audio.import-3f6734d95ce3b8e4/preprocessed.wav"
,"compand"
,".1,.2"
,"-inf,-50.1,-inf,-50,-50"
,"0"
,"-90"
,".1"
]
```