### PR TITLE
Only push if Cachix secure env var is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,16 @@ env:
   global:
   - secure: FZYy1mgp2HWwWq3KFsfIcYFjKGTNnQaTUF9tZHgKsMgOwQxKDQNC+NaLrsXNbd0LlSpa3g4RDERq+1eFINjIcDlNyzk/eZawJ+CFDpDC2nzUTG9SwwbQ3JdUdQcvlayzAWlD8uvj3ygID6vKSqxIovY6pySsbcGBOxoPkeYKhrgT3tSETmcpS+dp1W0jMfjk8TJfbTm8mjRZmjOuFuDO7uFMKfy42gz5uwjY/Z4qmhl4AP6nwVp0eP9/b8w5GZF4Rka47GIHBLJPcGJSj8zxo+xVbGgkzzGouhCAUjITWMUt67JBNfckWEJPVDzcfd1CxQz0i1jUkxhaA+EVqeKJwk+9N0PeQyT8xSuDTE59lq+FZHDdFxiprzb/TEXBdWIr5+QEVHHgsxt/RC5LyMb4VWU1eNCpmvTwOReXirOmQWhQKXyLuKvMcV6eyxK0CbN+jb2i7rJofzui34sGchgBcAql5WenjZBKkJC3G6976OxzeUTM7+Qi35qK+RBSQrCvdzPrdEG0Y0YckEzXawi4Fuka5iuw3t7Vx2yrNPrlEgioBtv9k+xopxmqBE73FAomNdpaTKrAJotuTasoIPIOz5cuaZdfmDsGwmbDnQFSGQQwSj8LekTq5h6rQPoUx0PZsWFDiAl7woMLT4bOOR2bAUExpMmhKBESbPoXLqkO7X4=
 script:
+# Cachix setup
 - nix-env -if https://github.com/cachix/cachix/tarball/master --extra-substituters https://cachix.cachix.org --trusted-public-keys 'cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM='
 - cachix use komposition
-- cachix push komposition --watch-store&
-- nix-build -j2 -A komposition | cachix push komposition
+- |
+  # Only push if branch to Cachix is from origin, and thus having the
+  # required secure environment variable set.
+  if [ -n "$CACHIX_SIGNING_KEY"]; then
+     cachix push komposition --watch-store&
+     nix-build -j2 -A komposition | cachix push komposition
+  else
+     nix-build -j2 -A komposition
+  fi
+


### PR DESCRIPTION
This will let pull requests from forks build properly on Travis CI, not failing on the `cachix push` command.