### PR TITLE
Include missing lib in installation docs

### DIFF
--- a/docs/src/user-guide/installation.md
+++ b/docs/src/user-guide/installation.md
@@ -52,6 +52,7 @@ sudo apt-get install \
     libgdk-pixbuf2.0-dev \
     libgstreamer1.0-dev \
     gstreamer1.0-libav \
+    gstreamer1.0-gtk3 \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad


### PR DESCRIPTION
When attempting to preview a parallel in komposition I was getting the error `Couldn't create GStreamer GTK sink` (as per https://github.com/owickstrom/komposition/issues/45), I resolved this by installing `gstreamer1.0-gtk3` which was outlined in this similar issue https://github.com/otsaloma/gaupol/issues/83#issuecomment-377656428.

This PR adds this dependency to the installation guide.