### PR TITLE
Fix confirm exit loosing state

### DIFF
--- a/src/Komposition/Application/TimelineMode.hs
+++ b/src/Komposition/Application/TimelineMode.hs
@@ -42,7 +42,7 @@ import           Komposition.Application.KeyMaps
 import           Komposition.Application.LibraryMode
 
 data TimelineModeResult
-  = TimelineExit
+  = TimelineExit TimelineModel
   | TimelineClose
 
 timelineMode
@@ -152,7 +152,7 @@ timelineMode gui model = do
       CommandKeyMappedEvent Cancel -> continue
       CommandKeyMappedEvent Help ->
         help gui [ModeKeyMap STimelineMode (keymaps STimelineMode)] >>> continue
-      CommandKeyMappedEvent Exit -> ireturn TimelineExit
+      CommandKeyMappedEvent Exit -> ireturn (TimelineExit model)
       ZoomLevelChanged zl -> model & zoomLevel .~ zl & timelineMode gui
     printUnexpectedFocusError err cmd =
       case err of

--- a/src/Komposition/Application/WelcomeScreenMode.hs
+++ b/src/Komposition/Application/WelcomeScreenMode.hs
@@ -72,11 +72,11 @@ toTimelineWithProject gui project = do
   where
     runTimeline model =
       timelineMode gui model >>= \case
-        TimelineExit ->
+        TimelineExit model' ->
           dialog gui "Confirm Exit" "Are you sure you want to exit?" [No, Yes] >>>= \case
             Just Yes -> exit gui
-            Just No -> runTimeline model
-            Nothing -> runTimeline model
+            Just No -> runTimeline model'
+            Nothing -> runTimeline model'
         TimelineClose -> returnToWelcomeScreen gui >>> welcomeScreenMode gui
 
 data Confirmation

--- a/src/Komposition/UserInterface/GtkInterface/ThumbnailPreview.hs
+++ b/src/Komposition/UserInterface/GtkInterface/ThumbnailPreview.hs
@@ -45,7 +45,7 @@ instance Patchable ThumbnailPreview where
       h <- Gdk.getRectangleHeight a
       redraw w h
     Gtk.toWidget layout
-  patch old new 
+  patch old new
     | thumbnailPath old == thumbnailPath new = Keep
     | otherwise = Replace (create new)
 


### PR DESCRIPTION
**Description:**

This pull request fixes an issue where trying to exit, but not confirming the exit, reverts the project to its initial state (as it was created or opened from the welcome screen.

Tested on new and existing projects.

**Checklist:**

- [x] Doesn't duplicate any existing PR

**How to test:**

1. Open or create a project
2. Make some changes (like adding clips)
3. Press the escape key or click Exit
4. Click "No" or escape key
5. Your project should be in the same stat it was after step 2
