### PR TITLE
Inline audio ffmpeg filter

### DIFF
--- a/src/Komposition/FFmpeg/Command.hs
+++ b/src/Komposition/FFmpeg/Command.hs
@@ -24,8 +24,8 @@ where
 import           Komposition.Prelude
 import qualified Prelude
 
-import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.Text          as Text
+import qualified Data.List.NonEmpty    as NonEmpty
+import qualified Data.Text             as Text
 import           Text.Printf
 
 import           Komposition.Duration
@@ -53,7 +53,6 @@ data Command = Command
 data Source
   = FileSource FilePath
   | StillFrameSource FilePath FrameRate Duration
-  | AudioNullSource Duration
 
 type Name = Text
 
@@ -91,6 +90,8 @@ data Filter
               , trimDuration :: Duration }
   | SetPTSStart
   | AudioSetPTSStart
+
+  | AudioEvalSource { audioEvalSourceDuration :: Duration }
 
 data RoutedFilter = RoutedFilter
   { filterInputs  :: [StreamSelector]
@@ -138,12 +139,6 @@ printSourceArgs =
       , printTimestamp duration
       , "-i"
       , toS path
-      ]
-    AudioNullSource d ->
-      [ "-f"
-      , "lavfi"
-      , "-i"
-      , "aevalsrc=0:duration=" <> show (durationToSeconds d)
       ]
 
 printMapping :: StreamSelector -> [Text]
@@ -194,6 +189,11 @@ printFilter =
            -- decimal numbers
            (durationToSeconds trimStart)
            (durationToSeconds trimDuration) :: Prelude.String)
+
+    AudioEvalSource {..} ->
+      toS (printf
+            "aevalsrc=0:duration=%f"
+            (durationToSeconds audioEvalSourceDuration) :: Prelude.String)
     AudioTrim {..} ->
       toS
         (printf

--- a/src/Komposition/Render/FFmpeg.hs
+++ b/src/Komposition/Render/FFmpeg.hs
@@ -347,7 +347,7 @@ extractFrameToFile' videoSettings mode videoSource videoAsset ts frameDir = do
               , "1"
               , frameFileName
               ]
-        putStrLn $ Text.unwords ("ffmpeg" : map toS allArgs)
+        printEscapedFFmpegInvocation (map toS allArgs)
         runFFmpeg $ proc "ffmpeg" allArgs
     runFFmpeg cmd = do
       (exit, _, err) <- readCreateProcessWithExitCode cmd ""

--- a/test/Komposition/FFmpeg/CommandTest.hs
+++ b/test/Komposition/FFmpeg/CommandTest.hs
@@ -14,7 +14,8 @@ import           Komposition.FFmpeg.Command
 spec_printCommandLineArgs = do
   it "prints command-line args for a multi-chain concat command" $
     let videoStream = StreamSelector (StreamName "video") Nothing Nothing
-        audioStream = StreamSelector (StreamName "audio") Nothing Nothing
+        audioStream1 = StreamSelector (StreamName "audio1") Nothing Nothing
+        audioStream2 = StreamSelector (StreamName "audio2") Nothing Nothing
         filter1a =
           RoutedFilter
             [ StreamSelector (StreamIndex 0) (Just Video) (Just 0)
@@ -28,16 +29,17 @@ spec_printCommandLineArgs = do
             [StreamSelector (StreamIndex 2) (Just Audio) (Just 0)]
             (Concat 1 0 1)
             []
-        filter2b = RoutedFilter [] AudioSetPTSStart [audioStream]
+        filter2b = RoutedFilter [] AudioSetPTSStart [audioStream1]
+        filter3a = RoutedFilter [] (AudioEvalSource 4) [audioStream2]
         chain1 = FilterChain (filter1a :| [filter1b])
         chain2 = FilterChain (filter2a :| [filter2b])
-        filterGraph = Just (FilterGraph (chain1 :| [chain2]))
+        chain3 = FilterChain (pure filter3a)
+        filterGraph = Just (FilterGraph (chain1 :| [chain2, chain3]))
         inputs =
           (FileSource "foo.mp4" :|
            [ StillFrameSource "bar.png" 25 10
-           , AudioNullSource (durationFromSeconds 4.3)
            ])
-        mappings = [videoStream, audioStream]
+        mappings = [videoStream, audioStream1, audioStream2]
         format = Just "mp4"
         output = FileOutput "bar.mp4"
         frameRate = Nothing
@@ -55,16 +57,14 @@ spec_printCommandLineArgs = do
        , "00:00:10.0"
        , "-i"
        , "bar.png"
-       , "-f"
-       , "lavfi"
-       , "-i"
-       , "aevalsrc=0:duration=4.3"
        , "-filter_complex"
-       , "[0:v:0][1:v:0]concat=n=2:v=1:a=0,setpts=PTS-STARTPTS[video];[2:a:0]concat=n=1:v=0:a=1,asetpts=PTS-STARTPTS[audio]"
+       , "[0:v:0][1:v:0]concat=n=2:v=1:a=0,setpts=PTS-STARTPTS[video];[2:a:0]concat=n=1:v=0:a=1,asetpts=PTS-STARTPTS[audio1];aevalsrc=0:duration=4.0[audio2]"
        , "-map"
        , "[video]"
        , "-map"
-       , "[audio]"
+       , "[audio1]"
+       , "-map"
+       , "[audio2]"
        , "-f"
        , "mp4"
        , "bar.mp4"


### PR DESCRIPTION
Improves rendering performance by inlining silent audio generation into the filter_complex graph, and by actually using video proxies in preview (this was a bug!)