### PR TITLE
Set video settings on create and transcode for rendering

### DIFF
--- a/komposition.cabal
+++ b/komposition.cabal
@@ -72,7 +72,10 @@ library
                       , Komposition.UserInterface.GtkInterface.HelpView
                       , Komposition.UserInterface.GtkInterface.ImportView
                       , Komposition.UserInterface.GtkInterface.LibraryView
+                      , Komposition.UserInterface.GtkInterface.NewProjectView
+                      , Komposition.UserInterface.GtkInterface.NumberInput
                       , Komposition.UserInterface.GtkInterface.RangeSlider
+                      , Komposition.UserInterface.GtkInterface.SelectBox
                       , Komposition.UserInterface.GtkInterface.TimelineView
                       , Komposition.UserInterface.GtkInterface.ThumbnailPreview
                       , Komposition.UserInterface.GtkInterface.WelcomeScreenView

--- a/src/Komposition/Application/ImportMode.hs
+++ b/src/Komposition/Application/ImportMode.hs
@@ -111,7 +111,7 @@ importSelectedFile gui project (filepath, classify) = do
         ilift $
         importVideoFile
           classification
-          (current (project ^. projectHistory) ^. proxyVideoSettings)
+          (current (project ^. projectHistory) ^. videoSettings)
           filepath
           (project ^. projectPath . unProjectPath)
       result <- progressBar gui "Importing Video" action

--- a/src/Komposition/Application/KeyMaps.hs
+++ b/src/Komposition/Application/KeyMaps.hs
@@ -39,6 +39,11 @@ keymaps =
       , ([KeyEscape], Mapping Cancel)
       , ([KeyChar '?'], Mapping Help)
       ]
+    SNewProjectMode ->
+      [ ([KeyChar 'q'], Mapping Cancel)
+      , ([KeyEscape], Mapping Cancel)
+      , ([KeyChar '?'], Mapping Help)
+      ]
     STimelineMode ->
       [ ([KeyChar 'h'], Mapping (FocusCommand FocusLeft))
       , ([KeyChar 'j'], Mapping (FocusCommand FocusDown))

--- a/src/Komposition/Application/TimelineMode.hs
+++ b/src/Komposition/Application/TimelineMode.hs
@@ -39,6 +39,7 @@ import           Komposition.Render
 import qualified Komposition.Render.Composition      as Render
 import           Komposition.UserInterface.Dialog
 import           Komposition.UserInterface.Help
+import           Komposition.VideoSettings
 
 import           Komposition.Application.ImportMode
 import           Komposition.Application.KeyMaps
@@ -145,8 +146,8 @@ timelineMode gui model = do
               Just outFile -> do
                 stream <-
                   ilift $ renderComposition
-                    (currentProject model ^. videoSettings)
-                    VideoOriginal
+                    (currentProject model ^. videoSettings . renderVideoSettings)
+                    VideoTranscoded
                     (FileOutput outFile)
                     flat
                 progressBar gui "Rendering" stream >>= \case
@@ -285,14 +286,14 @@ previewFocusedComposition
 previewFocusedComposition gui model = case flatComposition of
   Just flat -> do
     streamingProcess <- ilift $ renderComposition
-      (currentProject model ^. proxyVideoSettings)
+      (currentProject model ^. videoSettings . proxyVideoSettings)
       VideoProxy
       (HttpStreamingOutput "localhost" 12345)
       flat
     _ <- previewStream gui
                       "http://localhost:12345"
                       streamingProcess
-                      (currentProject model ^. proxyVideoSettings)
+                      (currentProject model ^. videoSettings . proxyVideoSettings)
     ireturn model
   Nothing -> do
     beep gui
@@ -407,7 +408,7 @@ toVideoClip model videoAsset =
           (videoAsset ^. videoClassifiedScene)
   in VideoClip () videoAsset ts <$>
       extractFrameToFile
-        (currentProject model ^. videoSettings)
+        (currentProject model ^. videoSettings . proxyVideoSettings)
         Render.FirstFrame
         VideoProxy
         videoAsset

--- a/src/Komposition/Import/Video.hs
+++ b/src/Komposition/Import/Video.hs
@@ -20,9 +20,9 @@ import           Komposition.Progress
 import           Komposition.VideoSettings
 
 data VideoImport (m :: * -> *) k
-  = GenerateProxy VideoSettings OriginalPath Duration FilePath (Producer ProgressUpdate (SafeT IO) ProxyPath -> k)
+  = Transcode VideoSettings OriginalPath Duration FilePath (Producer ProgressUpdate (SafeT IO) TranscodedPath -> k)
   | GenerateVideoThumbnail OriginalPath FilePath (Maybe FilePath -> k)
-  | ImportVideoFile Classification VideoSettings FilePath FilePath (Producer ProgressUpdate (SafeT IO) [VideoAsset] -> k)
+  | ImportVideoFile Classification AllVideoSettings FilePath FilePath (Producer ProgressUpdate (SafeT IO) [VideoAsset] -> k)
   | IsSupportedVideoFile FilePath (Bool -> k)
   deriving (Functor)
 
@@ -38,20 +38,20 @@ generateVideoThumbnail
 generateVideoThumbnail srcFile outDir =
   send (GenerateVideoThumbnail srcFile outDir ret)
 
-generateProxy
+transcode
   :: (Member VideoImport sig, Carrier sig m)
   => VideoSettings
   -> OriginalPath
   -> Duration
   -> FilePath
-  -> m (Producer ProgressUpdate (SafeT IO) ProxyPath)
-generateProxy settings original fullLength outDir =
-  send (GenerateProxy settings original fullLength outDir ret)
+  -> m (Producer ProgressUpdate (SafeT IO) TranscodedPath)
+transcode settings original fullLength outDir =
+  send (Transcode settings original fullLength outDir ret)
 
 importVideoFile
   :: (Member VideoImport sig, Carrier sig m)
   => Classification
-  -> VideoSettings
+  -> AllVideoSettings
   -> FilePath
   -> FilePath
   -> m (Producer ProgressUpdate (SafeT IO) [VideoAsset])

--- a/src/Komposition/Import/Video/FFmpeg.hs
+++ b/src/Komposition/Import/Video/FFmpeg.hs
@@ -259,14 +259,15 @@ getVideoFileDuration f =
 
 filePathToVideoAsset ::
      (MonadMask m, MonadSafe m, MonadIO m)
-  => VideoSettings
+  => AllVideoSettings
   -> FilePath
   -> OriginalPath
   -> Producer ProgressUpdate m VideoAsset
-filePathToVideoAsset videoSettings outDir p = do
+filePathToVideoAsset vs outDir p = do
   d <- liftIO (getVideoFileDuration (p ^. unOriginalPath))
-  proxyPath <- generateProxy' videoSettings p d (outDir </> "proxies")
-  pure (VideoAsset (AssetMetadata p d) proxyPath Nothing)
+  transcodedPath <- transcode' (vs ^. renderVideoSettings) p d (outDir </> "transcoded")
+  proxyPath <- transcode' (vs ^. proxyVideoSettings) p d (outDir </> "proxies")
+  pure (VideoAsset (AssetMetadata p d) transcodedPath proxyPath Nothing)
 
 generateVideoThumbnail' ::
      (MonadIO m)
@@ -285,16 +286,17 @@ generateVideoThumbnail' (view unOriginalPath -> sourceFile) outDir = do
       liftIO cleanup
       pure Nothing
 
-generateProxy' ::
+transcode' ::
      (MonadIO m, MonadSafe m)
   => VideoSettings
   -> OriginalPath
   -> Duration
   -> FilePath
-  -> Producer ProgressUpdate m ProxyPath
-generateProxy' videoSettings (view unOriginalPath -> sourceFile) fullLength outDir = do
+  -> Text
+  -> Producer ProgressUpdate m TranscodedPath
+transcode' videoSettings (view unOriginalPath -> sourceFile) fullLength outDir progressMsg = do
   liftIO (createDirectoryIfMissing True outDir)
-  let proxyPath = outDir </> takeBaseName sourceFile <> ".proxy.mp4"
+  let proxyPath = outDir </> takeBaseName sourceFile <> ".transcoded.mp4"
       cmd =
         Command
         { output = Command.FileOutput proxyPath
@@ -314,11 +316,11 @@ generateProxy' videoSettings (view unOriginalPath -> sourceFile) fullLength outD
         , frameRate = Just (videoSettings ^. frameRate)
         , mappings = []
         , vcodec = Just "h264"
-        , acodec = Nothing
+        , acodec = Just "aac"
         , format = Just "mp4"
         }
-  runFFmpegCommand (ProgressUpdate "Generating proxy") fullLength cmd
-  return (ProxyPath proxyPath)
+  runFFmpegCommand (ProgressUpdate progressMsg) fullLength cmd
+  return (TranscodedPath proxyPath)
 
 newtype FFmpegVideoImportC m a = FFmpegVideoImportC { runFFmpegVideoImportC :: m a }
   deriving (Functor, Applicative, Monad, MonadIO)
@@ -326,9 +328,9 @@ newtype FFmpegVideoImportC m a = FFmpegVideoImportC { runFFmpegVideoImportC :: m
 instance (MonadIO m, Carrier sig m) => Carrier (VideoImport :+: sig) (FFmpegVideoImportC m) where
   ret = pure
   eff = handleSum (FFmpegVideoImportC . eff . handleCoercible) $ \case
-    GenerateProxy settings original fullLength outDir k -> k (generateProxy' settings original fullLength outDir)
+    Transcode settings original fullLength outDir k -> k (transcode' settings original fullLength outDir "Transcoding video file")
     GenerateVideoThumbnail original outDir k -> k =<< generateVideoThumbnail' original outDir
-    ImportVideoFile classification settings srcFile outDir k ->
+    ImportVideoFile classification vs srcFile outDir k ->
       case classification of
         Unclassified -> k $ do
           -- Copy asset to working directory
@@ -338,20 +340,22 @@ instance (MonadIO m, Carrier sig m) => Carrier (VideoImport :+: sig) (FFmpegVide
             copyFile srcFile assetPath
             return (OriginalPath assetPath)
           -- Generate thumbnail and return asset
-          pure <$> filePathToVideoAsset settings outDir assetPath
+          pure <$> filePathToVideoAsset vs outDir assetPath
         Classified   -> k $ do
           fullLength <- liftIO (getVideoFileDuration srcFile)
-          generateProxy' settings original fullLength (outDir </> "proxies")
-            & flip divideProgress2 (classifyScenes fullLength)
+          divideProgress3
+            (transcode' (vs ^. renderVideoSettings) original fullLength (outDir </> "transcoded") "Transcoding video to project settings")
+            (\x -> (x,) <$> transcode' (vs ^. proxyVideoSettings) original fullLength (outDir </> "proxies") "Generating proxy video")
+            (classifyScenes fullLength)
           where
             original = OriginalPath srcFile
-            toSceneAsset proxyPath fullLength n timeSpan = do
+            toSceneAsset (transcodedPath, proxyPath) fullLength n timeSpan = do
               let meta = AssetMetadata original fullLength
-              return (VideoAsset meta proxyPath (Just (n, timeSpan)))
-            classifyScenes fullLength proxyPath =
+              return (VideoAsset meta transcodedPath proxyPath (Just (n, timeSpan)))
+            classifyScenes fullLength paths@(_, proxyPath) =
               classifyMovement 1.0 (readVideoFile (proxyPath ^. unProxyPath) >-> toMassiv)
                 & classifyMovingScenes fullLength
-                & (>>= zipWithM (toSceneAsset proxyPath fullLength) [1 ..])
+                & (>>= zipWithM (toSceneAsset paths fullLength) [1 ..])
     IsSupportedVideoFile p k ->
         -- TODO: actual check using FFmpeg
         k (takeExtension p `elem` [".mp4", ".m4v", ".webm", ".avi", ".mkv", ".mov", ".flv"])

--- a/src/Komposition/Import/Video/FFmpeg.hs
+++ b/src/Komposition/Import/Video/FFmpeg.hs
@@ -265,8 +265,8 @@ filePathToVideoAsset ::
   -> Producer ProgressUpdate m VideoAsset
 filePathToVideoAsset vs outDir p = do
   d <- liftIO (getVideoFileDuration (p ^. unOriginalPath))
-  transcodedPath <- transcode' (vs ^. renderVideoSettings) p d (outDir </> "transcoded")
-  proxyPath <- transcode' (vs ^. proxyVideoSettings) p d (outDir </> "proxies")
+  transcodedPath <- transcode' (vs ^. renderVideoSettings) p d (outDir </> "transcoded") "Transcoding video file"
+  proxyPath <- transcode' (vs ^. proxyVideoSettings) p d (outDir </> "proxies") "Generating proxy video"
   pure (VideoAsset (AssetMetadata p d) transcodedPath proxyPath Nothing)
 
 generateVideoThumbnail' ::

--- a/src/Komposition/Library.hs
+++ b/src/Komposition/Library.hs
@@ -28,15 +28,16 @@ data AssetMetadata = AssetMetadata
 
 makeLenses ''AssetMetadata
 
-newtype ProxyPath = ProxyPath
+newtype TranscodedPath = TranscodedPath
   { _unProxyPath :: FilePath
   } deriving (Show, Eq, Generic)
 
-makeLenses ''ProxyPath
+makeLenses ''TranscodedPath
 
 data VideoAsset =
   VideoAsset { _videoAssetMetadata   :: AssetMetadata
-             , _videoAssetProxy      :: ProxyPath
+             , _videoAssetTranscoded :: TranscodedPath
+             , _videoAssetProxy      :: TranscodedPath
              , _videoClassifiedScene :: Maybe (Integer, TimeSpan)
              }
   deriving (Show, Eq, Generic)

--- a/src/Komposition/Project.hs
+++ b/src/Komposition/Project.hs
@@ -14,17 +14,16 @@ import           Komposition.Prelude
 import           Control.Lens
 import           Data.Text                 (Text)
 
-import           Komposition.History
 import           Komposition.Composition
+import           Komposition.History
 import           Komposition.Library
 import           Komposition.VideoSettings
 
 data Project = Project
-  { _projectName        :: Text
-  , _timeline           :: Timeline ()
-  , _library            :: Library
-  , _videoSettings      :: VideoSettings
-  , _proxyVideoSettings :: VideoSettings
+  { _projectName   :: Text
+  , _timeline      :: Timeline ()
+  , _library       :: Library
+  , _videoSettings :: AllVideoSettings
   } deriving (Eq, Show, Generic)
 
 makeLenses ''Project
@@ -35,7 +34,7 @@ newtype ProjectPath = ProjectPath { _unProjectPath :: FilePath }
 makeLenses ''ProjectPath
 
 data ExistingProject = ExistingProject
-  { _projectPath :: ProjectPath
+  { _projectPath    :: ProjectPath
   , _projectHistory :: History Project
   } deriving (Eq, Show)
 

--- a/src/Komposition/Project/Store/File.hs
+++ b/src/Komposition/Project/Store/File.hs
@@ -34,7 +34,7 @@ import           System.FilePath
 instance Binary AssetMetadata
 instance Binary VideoAsset
 instance Binary AudioAsset
-instance Binary ProxyPath
+instance Binary TranscodedPath
 instance Binary OriginalPath
 
 instance Binary Duration where
@@ -51,6 +51,7 @@ instance Binary a => Binary (Timeline a)
 instance Binary Library
 instance Binary Resolution
 instance Binary VideoSettings
+instance Binary AllVideoSettings
 instance Binary Project
 
 instance Binary a => Binary (History a)

--- a/src/Komposition/Render.hs
+++ b/src/Komposition/Render.hs
@@ -78,13 +78,13 @@ extractFrameToFile settings stillFrameMode videoSource asset timeSpan outDir =
   send (ExtractFrameToFile settings stillFrameMode videoSource asset timeSpan outDir ret)
 
 data Source (mt :: MediaType) where
-  VideoOriginal :: Source Video
+  VideoTranscoded :: Source Video
   VideoProxy :: Source Video
   AudioOriginal :: Source Audio
 
 instance Hashable (Source mt) where
   hashWithSalt s = \case
-    VideoOriginal -> s
+    VideoTranscoded -> s
     VideoProxy    -> s + 1
     AudioOriginal -> s + 2
 

--- a/src/Komposition/Render/FFmpeg.hs
+++ b/src/Komposition/Render/FFmpeg.hs
@@ -299,8 +299,8 @@ instance (MonadIO m, Carrier sig m) => Carrier (Render :+: sig) (FFmpegRenderC m
 videoAssetSourcePath :: Source Video -> Asset Video -> FilePath
 videoAssetSourcePath videoSource videoAsset =
   case videoSource of
-    VideoOriginal -> videoAsset ^. assetMetadata . path . unOriginalPath
-    VideoProxy -> videoAsset ^. videoAssetProxy . unProxyPath
+    VideoTranscoded -> videoAsset ^. assetMetadata . path . unOriginalPath
+    VideoProxy      -> videoAsset ^. videoAssetProxy . unProxyPath
 
 extractFrameToFile' ::
      VideoSettings

--- a/src/Komposition/UserInterface.hs
+++ b/src/Komposition/UserInterface.hs
@@ -35,12 +35,14 @@ import           Komposition.VideoSettings
 
 data Mode
   = WelcomeScreenMode
+  | NewProjectMode
   | TimelineMode
   | LibraryMode
   | ImportMode
 
 data SMode m where
   SWelcomeScreenMode :: SMode WelcomeScreenMode
+  SNewProjectMode :: SMode NewProjectMode
   STimelineMode :: SMode TimelineMode
   SLibraryMode :: SMode LibraryMode
   SImportMode :: SMode ImportMode
@@ -48,6 +50,7 @@ data SMode m where
 modeTitle :: SMode m -> Text
 modeTitle = \case
   SWelcomeScreenMode -> "Welcome Screen Mode"
+  SNewProjectMode -> "New Project Mode"
   STimelineMode -> "Timeline Mode"
   SLibraryMode  -> "Library Mode"
   SImportMode   -> "Import Mode"
@@ -132,6 +135,10 @@ data Event mode where
   CommandKeyMappedEvent :: Command mode -> Event mode
   CreateNewProjectClicked :: Event WelcomeScreenMode
   OpenExistingProjectClicked :: Event WelcomeScreenMode
+  ProjectNameChanged :: Text -> Event NewProjectMode
+  FrameRateChanged :: FrameRate -> Event NewProjectMode
+  ResolutionChanged :: Resolution -> Event NewProjectMode
+  CreateClicked :: Event NewProjectMode
   ZoomLevelChanged :: ZoomLevel -> Event TimelineMode
   ImportFileSelected :: Maybe FilePath -> Event ImportMode
   ImportAutoSplitSet :: Bool -> Event ImportMode
@@ -164,6 +171,14 @@ data TimelineModel = TimelineModel
 
 makeLenses ''TimelineModel
 
+data NewProjectModel = NewProjectModel
+  { _newProjectName       :: Text
+  , _newProjectFrameRate  :: FrameRate
+  , _newProjectResolution :: Resolution
+  }
+
+makeLenses ''NewProjectModel
+
 currentProject :: TimelineModel -> Project
 currentProject = current . view (existingProject . projectHistory)
 
@@ -184,6 +199,7 @@ data PromptMode ret where
 
 class UserInterfaceMarkup markup where
   welcomeView :: markup (Event WelcomeScreenMode)
+  newProjectView :: NewProjectModel -> markup (Event NewProjectMode)
   timelineView :: TimelineModel -> markup (Event TimelineMode)
   libraryView :: SelectAssetsModel mediaType -> markup (Event LibraryMode)
   importView :: ImportFileModel -> markup (Event ImportMode)

--- a/src/Komposition/UserInterface/GtkInterface.hs
+++ b/src/Komposition/UserInterface/GtkInterface.hs
@@ -76,6 +76,7 @@ import           Komposition.VideoSettings
 
 import qualified Komposition.UserInterface.GtkInterface.ImportView        as View
 import qualified Komposition.UserInterface.GtkInterface.LibraryView       as View
+import qualified Komposition.UserInterface.GtkInterface.NewProjectView    as View
 import qualified Komposition.UserInterface.GtkInterface.TimelineView      as View
 import qualified Komposition.UserInterface.GtkInterface.WelcomeScreenView as View
 
@@ -160,6 +161,8 @@ instance (Member (Reader Env) sig, Carrier sig m, MonadIO m) => WindowUserInterf
         >>>= \w -> irunUI (do
           cw <- asGtkWindow w
           pw <- asGtkWindow p
+          Gtk.windowSetModal cw True
+          Gtk.windowSetTypeHint cw Gdk.WindowTypeHintDialog
           Gtk.windowSetTransientFor cw (Just pw))
         >>> action
         >>>= \x ->
@@ -347,6 +350,7 @@ instance (Member (Reader Env) sig, Carrier sig m, MonadIO m) => WindowUserInterf
 
 instance UserInterfaceMarkup GtkWindowMarkup where
   welcomeView = GtkWindowMarkup View.welcomeScreenView
+  newProjectView = GtkWindowMarkup . View.newProjectView
   timelineView = GtkWindowMarkup . View.timelineView
   libraryView = GtkWindowMarkup . View.libraryView
   importView = GtkWindowMarkup . View.importView

--- a/src/Komposition/UserInterface/GtkInterface/CustomWidget.hs
+++ b/src/Komposition/UserInterface/GtkInterface/CustomWidget.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 module Komposition.UserInterface.GtkInterface.CustomWidget where
 
-import Komposition.Prelude
+import           Komposition.Prelude
 
 import qualified GI.Gtk                         as Gtk
 import           GI.Gtk.Declarative

--- a/src/Komposition/UserInterface/GtkInterface/NewProjectView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/NewProjectView.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedLabels  #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Komposition.UserInterface.GtkInterface.NewProjectView
+  ( newProjectView
+  ) where
+
+import           Control.Lens
+import           Komposition.Prelude                                hiding
+                                                                     (State, on)
+
+import           GI.Gtk                                             (Align (..),
+                                                                     Box (..),
+                                                                     Button (..),
+                                                                     Entry (..),
+                                                                     Label (..),
+                                                                     Orientation (..),
+                                                                     Window (..),
+                                                                     entryGetText)
+import           GI.Gtk.Declarative                                 as Gtk
+
+import           Komposition.UserInterface                          hiding
+                                                                     (Window,
+                                                                     newProjectView)
+import           Komposition.UserInterface.GtkInterface.NumberInput
+import           Komposition.UserInterface.GtkInterface.SelectBox
+import           Komposition.VideoSettings
+
+newProjectView :: NewProjectModel -> Bin Window Widget (Event NewProjectMode)
+newProjectView model =
+  bin
+    Window
+    [ #title := "New Project"
+    , on #deleteEvent (const (True, WindowClosed))
+    ] $
+  container Box [classes ["new-project-view"], #orientation := OrientationVertical] $ do
+    boxChild False False 10 $
+      container Box [#orientation := OrientationHorizontal] $
+        boxChild True True 10 $ nameControl model
+    boxChild True True 10 $
+      container Box [#orientation := OrientationHorizontal, #valign := AlignStart] $ do
+        boxChild True True 10 $ frameRateControl model
+        boxChild True True 10 $ resolutionControl model
+    boxChild False False 10 $
+      container Box [#orientation := OrientationHorizontal, #halign := AlignEnd] $ do
+        boxChild True False 5 $ widget Button [#label := "Cancel", on #clicked WindowClosed]
+        boxChild True False 5 $ widget Button [#label := "Create", on #clicked CreateClicked]
+
+nameControl :: NewProjectModel -> Widget (Event NewProjectMode)
+nameControl model =
+  container Box [#orientation := OrientationVertical, #halign := AlignStart]
+    $ do
+        boxChild False False 5
+          $ widget Label [#label := "Name", #halign := AlignStart]
+        boxChild True True 5 $ widget
+          Entry
+          [ #text := (model ^. newProjectName)
+          , onM #changed (fmap ProjectNameChanged . entryGetText)
+          ]
+
+frameRateControl :: NewProjectModel -> Widget (Event NewProjectMode)
+frameRateControl model =
+  container Box [#orientation := OrientationVertical, #halign := AlignStart] $ do
+    boxChild False False 5 $
+      widget Label [#label := "Frame Rate", #halign := AlignStart]
+    boxChild False False 5 $
+      toFrameRateChanged <$>
+      numberInput NumberInputProperties{ value = fromIntegral (model ^. newProjectFrameRate)
+                                       , range = (15, 30)
+                                       , numberInputClasses = []
+                                       }
+  where
+    toFrameRateChanged (NumberInputChanged v) = FrameRateChanged v
+
+resolutionControl :: NewProjectModel -> Widget (Event NewProjectMode)
+resolutionControl model =
+  container Box [#orientation := OrientationVertical, #halign := AlignStart] $ do
+    boxChild False False 5 $
+      widget Label [#label := "Resolution", #halign := AlignStart]
+    boxChild False False 5 $ toResolutionChanged <$> selectBox
+      prettyPrintResolution
+      SelectBoxProperties
+        { selected         = model ^. newProjectResolution
+        , values           = resolutions
+        , selectBoxClasses = []
+        }
+  where toResolutionChanged (SelectBoxChanged r) = ResolutionChanged r

--- a/src/Komposition/UserInterface/GtkInterface/NumberInput.hs
+++ b/src/Komposition/UserInterface/GtkInterface/NumberInput.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Komposition.UserInterface.GtkInterface.NumberInput
+  ( NumberInputProperties (..)
+  , numberInput
+  , NumberInputEvent (..)
+  ) where
+
+import           Komposition.Prelude
+
+import qualified GI.GObject                                          as GI
+import qualified GI.Gtk                                              as Gtk
+import           GI.Gtk.Declarative
+import           GI.Gtk.Declarative.Attributes.Collected
+import           GI.Gtk.Declarative.EventSource
+import           GI.Gtk.Declarative.State
+
+import           Komposition.UserInterface.GtkInterface.CustomWidget
+
+data NumberInputProperties n = NumberInputProperties
+  { value              :: n
+  , range              :: (n, n)
+  , numberInputClasses :: ClassSet
+  } deriving (Eq, Show)
+
+
+newtype NumberInputEvent n = NumberInputChanged n
+
+numberInput
+  :: (Typeable n, Integral n)
+  => NumberInputProperties n
+  -> Widget (NumberInputEvent n)
+numberInput customData = Widget (CustomWidget {..})
+  where
+    customWidget = Gtk.SpinButton
+    customCreate props = do
+      spin <- Gtk.new Gtk.SpinButton []
+      adj <- propsToAdjustment props
+      Gtk.spinButtonSetAdjustment spin adj
+      sc <- Gtk.widgetGetStyleContext spin
+      updateClasses sc mempty (numberInputClasses props)
+      return (SomeState (StateTreeWidget (StateTreeNode spin sc mempty ())))
+
+    customPatch (SomeState st) old new
+      | old == new = CustomKeep
+      | otherwise = CustomModify $ \(spin :: Gtk.SpinButton) -> do
+        adj <- propsToAdjustment new
+        Gtk.spinButtonSetAdjustment spin adj
+        updateClasses (stateTreeStyleContext (stateTreeNode st))
+                      (numberInputClasses old)
+                      (numberInputClasses new)
+        return (SomeState st)
+
+    customSubscribe _ (spin :: Gtk.SpinButton) cb = do
+      h <- Gtk.on spin
+                  #valueChanged
+                  (cb . NumberInputChanged . round =<< #getValue spin)
+      return (fromCancellation (GI.signalHandlerDisconnect spin h))
+
+propsToAdjustment :: Integral n => NumberInputProperties n -> IO Gtk.Adjustment
+propsToAdjustment NumberInputProperties { value, range } =
+  Gtk.adjustmentNew (fromIntegral value) (fromIntegral (fst range)) (fromIntegral (snd range)) 1 1 0

--- a/src/Komposition/UserInterface/GtkInterface/SelectBox.hs
+++ b/src/Komposition/UserInterface/GtkInterface/SelectBox.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Komposition.UserInterface.GtkInterface.SelectBox
+  ( SelectBoxProperties (..)
+  , selectBox
+  , SelectBoxEvent (..)
+  ) where
+
+import           Komposition.Prelude
+
+import           Control.Lens
+import qualified Data.List.NonEmpty                                  as NonEmpty
+import qualified GI.GObject                                          as GI
+import qualified GI.Gtk                                              as Gtk
+import           GI.Gtk.Declarative
+import           GI.Gtk.Declarative.Attributes.Collected
+import           GI.Gtk.Declarative.EventSource
+import           GI.Gtk.Declarative.State
+
+import           Komposition.UserInterface.GtkInterface.CustomWidget
+
+data SelectBoxProperties a = SelectBoxProperties
+  { selected         :: a
+  , values           :: NonEmpty a
+  , selectBoxClasses :: ClassSet
+  } deriving (Eq, Show)
+
+
+newtype SelectBoxEvent a = SelectBoxChanged a
+
+selectBox
+  :: (Typeable a, Eq a)
+  => (a -> Text)
+  -> SelectBoxProperties a
+  -> Widget (SelectBoxEvent a)
+selectBox format customData = Widget (CustomWidget {..})
+  where
+    customWidget = Gtk.ComboBoxText
+    customCreate props = do
+      combo <- Gtk.new Gtk.ComboBoxText []
+      for_ (values props) $ \value ->
+        #appendText combo (format value)
+      case elemIndex (selected props) (values props) of
+        Just i  -> #setActive combo (fromIntegral i)
+        Nothing -> pass
+      sc <- Gtk.widgetGetStyleContext combo
+      updateClasses sc mempty (selectBoxClasses props)
+      return (SomeState (StateTreeWidget (StateTreeNode combo sc mempty ())))
+
+    customPatch (SomeState st) old new
+      | old == new = CustomKeep
+      | otherwise = CustomModify $ \(combo :: Gtk.ComboBoxText) -> do
+        #removeAll combo
+        for_ (values new) $ \value ->
+          #appendText combo (format value)
+        updateClasses (stateTreeStyleContext (stateTreeNode st))
+                      (selectBoxClasses old)
+                      (selectBoxClasses new)
+        return (SomeState st)
+
+    customSubscribe props (combo :: Gtk.ComboBoxText) cb = do
+      h <- Gtk.on combo
+                  #changed
+                  (cb
+                   . SelectBoxChanged
+                   . (values props NonEmpty.!!)
+                   . fromIntegral
+                   =<< #getActive combo)
+      return (fromCancellation (GI.signalHandlerDisconnect combo h))
+
+elemIndex :: (FoldableWithIndex i f, Eq a) => a -> f a -> Maybe i
+elemIndex x xs =
+  xs & ifind (const (== x)) & fmap fst

--- a/src/Komposition/VideoSettings.hs
+++ b/src/Komposition/VideoSettings.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE DeriveAnyClass  #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 module Komposition.VideoSettings where
 
 import           Komposition.Prelude
@@ -16,9 +17,27 @@ data Resolution = Resolution
 
 makeLenses ''Resolution
 
+prettyPrintResolution :: Resolution -> Text
+prettyPrintResolution (Resolution w h) =
+  show w <> "x" <> show h
+
+resolutions :: NonEmpty Resolution
+resolutions =
+  Resolution 1280 720
+  :| [ Resolution 1920 1080
+     , Resolution 2560 1440
+     , Resolution 3840 2160]
+
 data VideoSettings = VideoSettings
   { _frameRate  :: FrameRate
   , _resolution :: Resolution
   } deriving (Eq, Show, Generic, Hashable)
 
 makeLenses ''VideoSettings
+
+data AllVideoSettings = AllVideoSettings
+  { _renderVideoSettings :: VideoSettings
+  , _proxyVideoSettings  :: VideoSettings
+  } deriving (Eq, Show, Generic, Hashable)
+
+makeLenses ''AllVideoSettings

--- a/test/Komposition/Composition/Generators.hs
+++ b/test/Komposition/Composition/Generators.hs
@@ -41,7 +41,8 @@ videoAsset :: MonadGen m => m VideoAsset
 videoAsset = do
   meta <- assetMetadata
   tp <- TranscodedPath <$> Gen.string (linear 1 50) Gen.unicode
-  pure (VideoAsset meta tp Nothing)
+  pp <- TranscodedPath <$> Gen.string (linear 1 50) Gen.unicode
+  pure (VideoAsset meta tp pp Nothing)
 
 audioAsset :: MonadGen m => m AudioAsset
 audioAsset = AudioAsset <$> assetMetadata

--- a/test/Komposition/Composition/Generators.hs
+++ b/test/Komposition/Composition/Generators.hs
@@ -40,8 +40,8 @@ parallelWithClips = Parallel () <$> vs <*> as
 videoAsset :: MonadGen m => m VideoAsset
 videoAsset = do
   meta <- assetMetadata
-  proxyPath <- ProxyPath <$> Gen.string (linear 1 50) Gen.unicode
-  pure (VideoAsset meta proxyPath Nothing)
+  tp <- TranscodedPath <$> Gen.string (linear 1 50) Gen.unicode
+  pure (VideoAsset meta tp Nothing)
 
 audioAsset :: MonadGen m => m AudioAsset
 audioAsset = AudioAsset <$> assetMetadata

--- a/test/Komposition/FFmpeg/CommandTest.hs
+++ b/test/Komposition/FFmpeg/CommandTest.hs
@@ -8,7 +8,6 @@ import           Komposition.Prelude
 
 import           Test.Tasty.Hspec
 
-import           Komposition.Duration
 import           Komposition.FFmpeg.Command
 
 spec_printCommandLineArgs = do

--- a/test/Komposition/Project/Generators.hs
+++ b/test/Komposition/Project/Generators.hs
@@ -2,16 +2,18 @@
 
 module Komposition.Project.Generators where
 
-import           Komposition.Prelude                   hiding ( nonEmpty )
+import           Komposition.Prelude                hiding (nonEmpty)
 
 import           Hedgehog
-import qualified Hedgehog.Gen                  as Gen hiding (parallel)
+import qualified Hedgehog.Gen                       as Gen hiding (parallel)
 import           Hedgehog.Range
 
-import           Komposition.Project (Project(..))
-import           Komposition.Library
-import           Komposition.VideoSettings (VideoSettings(..), Resolution(..))
 import qualified Komposition.Composition.Generators as Gen
+import           Komposition.Library
+import           Komposition.Project                (Project (..))
+import           Komposition.VideoSettings          (AllVideoSettings (..),
+                                                     Resolution (..),
+                                                     VideoSettings (..))
 
 library :: MonadGen m => m Library
 library =
@@ -34,6 +36,8 @@ project = do
   _projectName <- Gen.text (linear 1 5) Gen.unicode
   _timeline <- Gen.timeline (linear 1 10) Gen.parallel
   _library <- library
-  _videoSettings <- videoSettings
-  _proxyVideoSettings <- videoSettings
+  _videoSettings <-
+    AllVideoSettings
+      <$> videoSettings
+      <*> videoSettings
   return Project{..}

--- a/test/Komposition/TestLibrary.hs
+++ b/test/Komposition/TestLibrary.hs
@@ -11,13 +11,13 @@ import           Komposition.Library
 video4s =
   VideoClip
     ()
-    (VideoAsset (AssetMetadata (OriginalPath "1.mp4") 4) (ProxyPath "1.proxy.mp4") Nothing)
+    (VideoAsset (AssetMetadata (OriginalPath "1.mp4") 4) (TranscodedPath "1.proxy.mp4") Nothing)
     (TimeSpan 0 4)
     "thumb.png"
 video10s =
   VideoClip
     ()
-    (VideoAsset (AssetMetadata (OriginalPath "2.mp4") 10) (ProxyPath "2.proxy.mp4") Nothing)
+    (VideoAsset (AssetMetadata (OriginalPath "2.mp4") 10) (TranscodedPath "2.proxy.mp4") Nothing)
     (TimeSpan 0 10)
     "thumb.png"
 audio1s = AudioClip () $ AudioAsset (AssetMetadata (OriginalPath "1.m4a") 1)

--- a/test/Komposition/TestLibrary.hs
+++ b/test/Komposition/TestLibrary.hs
@@ -11,13 +11,13 @@ import           Komposition.Library
 video4s =
   VideoClip
     ()
-    (VideoAsset (AssetMetadata (OriginalPath "1.mp4") 4) (TranscodedPath "1.proxy.mp4") Nothing)
+    (VideoAsset (AssetMetadata (OriginalPath "1.mp4") 4) (TranscodedPath "1.transcoded.mp4") (TranscodedPath "1.proxy.mp4") Nothing)
     (TimeSpan 0 4)
     "thumb.png"
 video10s =
   VideoClip
     ()
-    (VideoAsset (AssetMetadata (OriginalPath "2.mp4") 10) (TranscodedPath "2.proxy.mp4") Nothing)
+    (VideoAsset (AssetMetadata (OriginalPath "2.mp4") 10) (TranscodedPath "2.transcoded.mp4") (TranscodedPath "2.proxy.mp4") Nothing)
     (TimeSpan 0 10)
     "thumb.png"
 audio1s = AudioClip () $ AudioAsset (AssetMetadata (OriginalPath "1.m4a") 1)


### PR DESCRIPTION
**Description:**

This pull requests fixes #62, by transcoding all video files on import. It also adds a new dialog for setting video resolution and frame rate when creating new projects.

*Make sure to describe (where applicable):*

- New dialog when creating new projects for video settings
- This breaks the binary format of projects, so old projects won't be able to opened

**Checklist:**

Please make sure to check the following items (that are applicable.)

- [x] Doesn't duplicate any existing PR
