### PR TITLE
Implement copy/paste (yank in Vim lingo)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
             - user-guide/concepts/timeline.md
             - user-guide/concepts/navigation.md
             - user-guide/concepts/commands.md
+            - user-guide/concepts/clipboard.md
             - user-guide/concepts/undo-redo.md
             - user-guide/concepts/library.md
             - user-guide/concepts/importing.md

--- a/docs/src/user-guide/concepts/clipboard.md
+++ b/docs/src/user-guide/concepts/clipboard.md
@@ -1,0 +1,16 @@
+# Clipboard
+
+The clipboard is used for copying and pasting in the timeline. It can
+hold a single timeline part, i.e. a sequence, parallel, video part, or
+audio part.
+
+To copy the focused part of the timeline to the clipboard, press the
+<kbd>y</kbd> key. To paste the part stored in the clipboard, press the
+<kbd>p<kbd> key. This adds the clipboard part *after* your currently
+focused timeline part. If you want to add it *before*, use the
+uppercase <kbd>P<kbd> version of paste.
+
+Like in Vim, deleting something from the timeline also puts the
+deleted part in the clipboard. Mainstream software call this operation
+_cutting_. This is useful if you want to move something from one place
+to another, without making any intermediate copies.

--- a/docs/src/user-guide/concepts/commands.md
+++ b/docs/src/user-guide/concepts/commands.md
@@ -11,7 +11,6 @@ Most commands can also be issued by using the top-level menu bar.
 | Split     | Timeline                  | <kbd>s</kbd>                          | Split the currently focused composition, if possible      |
 | Delete    | Timeline                  | <kbd>d</kbd>                          | Delete the currently focused composition                  |
 | Import    | Timeline                  | <kbd>i</kbd>                          | Start a new asset import                                  |
-| Render    | Timeline                  | <kbd>r</kbd>                          | Render the project to a video file                        |
 | Preview   | Timeline                  | <kbd>Space</kbd>                      | Preview the currently focused composition                 |
 | Undo      | Timeline                  | <kbd>u</kbd>                          | Undo the last command                                     |
 | Redo      | Timeline                  | <kbd>Ctrl</kbd> + <kbd>r</kbd>        | Redo the last undone command                              |
@@ -23,26 +22,26 @@ Komposition to see the full listing.
 
 ## Key Sequences
 
-To *prepend* and *append* clips and gaps, there are key sequence bindings
-available. To prepend, you generally start by pressing <kbd>p</kbd> and then
-a key for the type of clip or gap you want to prepend. To append, start with
-the <kbd>a</kbd> key. Clips are specified with the <kbd>c</kbd> key, and gaps
-with the <kbd>g</kbd> key.
+To *add* clips and gaps, there are key sequence bindings available. To
+add after, you generally start by pressing <kbd>A</kbd> and then a key
+for the type of clip or gap you want to add. To add before, start with
+the <kbd>a</kbd> key. Clips are specified with the <kbd>c</kbd> key,
+and gaps with the <kbd>g</kbd> key.
 
 When a video or audio track is focused, you press two keys:
 
-1. prepend (<kbd>p</kbd>) or append (<kbd>a</kbd>)
+1. add after (<kbd>a</kbd>) or add before (<kbd>a</kbd>)
 2. clip (<kbd>c</kbd>) or gap (<kbd>g</kbd>)
 
 When a parallel is focused, you need to also specify if it's the video track
-or audio track you want to prepend or append to. The full key sequence then
+or audio track you want to add before or append to. The full key sequence then
 consists of three keys:
 
-1. prepend (<kbd>p</kbd>) or append (<kbd>a</kbd>)
+1. add before (<kbd>p</kbd>) or append (<kbd>a</kbd>)
 2. video (<kbd>v</kbd>) or audio track (<kbd>a</kbd>)
 3. clip (<kbd>c</kbd>) or gap (<kbd>g</kbd>)
 
-There are variations for prepending at the leftmost position (<kbd>P</kbd>),
-and appending at the rightmost position (<kbd>A</kbd>). And again, all key
-sequences are not listed in this document. Press <kbd>?</kbd> in Komposition
-to see the full listing.
+There are variations for adding at the leftmost position, and at the
+rightmost position, but those are currently only available in the menu
+bar. And again, all key sequences are not listed in this
+document. Press <kbd>?</kbd> in Komposition to see the full listing.

--- a/komposition.cabal
+++ b/komposition.cabal
@@ -38,6 +38,7 @@ library
                       , Komposition.Composition.Delete
                       , Komposition.Composition.Focused
                       , Komposition.Composition.Insert
+                      , Komposition.Composition.Paste
                       , Komposition.Composition.Split
                       , Komposition.Duration
                       , Komposition.FFmpeg.Command

--- a/src/Komposition/Application/KeyMaps.hs
+++ b/src/Komposition/Application/KeyMaps.hs
@@ -3,76 +3,74 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedLists   #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Komposition.Application.KeyMaps where
 
 import           Komposition.Application.Base
 
 import           Komposition.Composition.Insert
+import           Komposition.Composition.Paste
 import           Komposition.Focus
 import           Komposition.KeyMap
 import           Komposition.MediaType
 
-insertBindings :: InsertPosition -> KeyMapEntry (Command 'TimelineMode)
-insertBindings position =
-  SequencedMappings
-    [ ([KeyChar 'v'], mediaTypeBindings (Just Video))
-    , ([KeyChar 'a'], mediaTypeBindings (Just Audio))
-    , ([KeyChar 'c'], Mapping (InsertCommand (InsertClip Nothing) position))
-    , ([KeyChar 'g'], Mapping (InsertCommand (InsertGap Nothing) position))
-    , ([KeyChar 'p'], Mapping (InsertCommand InsertComposition LeftMost))
-    ]
+addBindings :: InsertPosition -> KeyMapEntry (Command 'TimelineMode)
+addBindings position = SequencedMappings
+  [ ([KeyChar 'v'], mediaTypeBindings (Just Video))
+  , ([KeyChar 'a'], mediaTypeBindings (Just Audio))
+  , ([KeyChar 'c'], Mapping (InsertCommand (InsertClip Nothing) position))
+  , ([KeyChar 'g'], Mapping (InsertCommand (InsertGap Nothing) position))
+  , ([KeyChar 'p'], Mapping (InsertCommand InsertComposition LeftMost))
+  ]
   where
-    mediaTypeBindings mediaType' =
-      SequencedMappings
-        [ ( [KeyChar 'c']
-          , Mapping (InsertCommand (InsertClip mediaType') position))
-        , ( [KeyChar 'g']
-          , Mapping (InsertCommand (InsertGap mediaType') position))
-        ]
+    mediaTypeBindings mediaType' = SequencedMappings
+      [ ( [KeyChar 'c']
+        , Mapping (InsertCommand (InsertClip mediaType') position)
+        )
+      , ([KeyChar 'g'], Mapping (InsertCommand (InsertGap mediaType') position))
+      ]
 
 keymaps :: SMode m -> KeyMap (Command m)
-keymaps =
-  \case
-    SWelcomeScreenMode ->
-      [ ([KeyChar 'q'], Mapping Cancel)
-      , ([KeyEscape], Mapping Cancel)
-      , ([KeyChar '?'], Mapping Help)
-      ]
-    SNewProjectMode ->
-      [ ([KeyChar 'q'], Mapping Cancel)
-      , ([KeyEscape], Mapping Cancel)
-      , ([KeyChar '?'], Mapping Help)
-      ]
-    STimelineMode ->
-      [ ([KeyChar 'h'], Mapping (FocusCommand FocusLeft))
-      , ([KeyChar 'j'], Mapping (FocusCommand FocusDown))
-      , ([KeyChar 'k'], Mapping (FocusCommand FocusUp))
-      , ([KeyChar 'l'], Mapping (FocusCommand FocusRight))
-      , ([KeyUp], Mapping (FocusCommand FocusUp))
-      , ([KeyDown], Mapping (FocusCommand FocusDown))
-      , ([KeyLeft], Mapping (FocusCommand FocusLeft))
-      , ([KeyRight], Mapping (FocusCommand FocusRight))
-      , ([KeyChar 'i'], Mapping Import)
-      , ([KeySpace], Mapping Preview)
-      , ([KeyChar 'p'], insertBindings LeftOf)
-      , ([KeyChar 'P'], insertBindings LeftMost)
-      , ([KeyChar 'a'], insertBindings RightOf)
-      , ([KeyChar 'A'], insertBindings RightMost)
-      , ([KeyChar 'd'], Mapping Delete)
-      , ([KeyChar 's'], Mapping Split)
-      , ([KeyChar 'u'], Mapping Undo)
-      , ([KeyModifier Ctrl, KeyChar 'r'], Mapping Redo)
-      , ([KeyChar '?'], Mapping Help)
-      , ([KeyChar 'q'], Mapping Exit)
-      ]
-    SLibraryMode ->
-      [ ([KeyChar 'q'], Mapping Cancel)
-      , ([KeyEscape], Mapping Cancel)
-      , ([KeyChar '?'], Mapping Help)
-      ]
-    SImportMode ->
-      [ ([KeyChar 'q'], Mapping Cancel)
-      , ([KeyEscape], Mapping Cancel)
-      , ([KeyChar '?'], Mapping Help)
-      ]
+keymaps = \case
+  SWelcomeScreenMode ->
+    [ ([KeyChar 'q'], Mapping Cancel)
+    , ([KeyEscape]  , Mapping Cancel)
+    , ([KeyChar '?'], Mapping Help)
+    ]
+  SNewProjectMode ->
+    [ ([KeyChar 'q'], Mapping Cancel)
+    , ([KeyEscape]  , Mapping Cancel)
+    , ([KeyChar '?'], Mapping Help)
+    ]
+  STimelineMode ->
+    [ ([KeyChar 'h']                  , Mapping (FocusCommand FocusLeft))
+    , ([KeyChar 'j']                  , Mapping (FocusCommand FocusDown))
+    , ([KeyChar 'k']                  , Mapping (FocusCommand FocusUp))
+    , ([KeyChar 'l']                  , Mapping (FocusCommand FocusRight))
+    , ([KeyUp]                        , Mapping (FocusCommand FocusUp))
+    , ([KeyDown]                      , Mapping (FocusCommand FocusDown))
+    , ([KeyLeft]                      , Mapping (FocusCommand FocusLeft))
+    , ([KeyRight]                     , Mapping (FocusCommand FocusRight))
+    , ([KeySpace]                     , Mapping Preview)
+    , ([KeyChar 'a']                  , addBindings RightOf)
+    , ([KeyChar 'A']                  , addBindings LeftOf)
+    , ([KeyChar 'd']                  , Mapping Delete)
+    , ([KeyChar 'p']                  , Mapping (Paste PasteRightOf))
+    , ([KeyChar 'P']                  , Mapping (Paste PasteLeftOf))
+    , ([KeyChar 'y']                  , Mapping Copy)
+    , ([KeyChar 's']                  , Mapping Split)
+    , ([KeyChar 'i']                  , Mapping Import)
+    , ([KeyChar 'u']                  , Mapping Undo)
+    , ([KeyModifier Ctrl, KeyChar 'r'], Mapping Redo)
+    , ([KeyChar '?']                  , Mapping Help)
+    , ([KeyChar 'q']                  , Mapping Exit)
+    ]
+  SLibraryMode ->
+    [ ([KeyChar 'q'], Mapping Cancel)
+    , ([KeyEscape]  , Mapping Cancel)
+    , ([KeyChar '?'], Mapping Help)
+    ]
+  SImportMode ->
+    [ ([KeyChar 'q'], Mapping Cancel)
+    , ([KeyEscape]  , Mapping Cancel)
+    , ([KeyChar '?'], Mapping Help)
+    ]

--- a/src/Komposition/Application/WelcomeScreenMode.hs
+++ b/src/Komposition/Application/WelcomeScreenMode.hs
@@ -99,7 +99,7 @@ toTimelineWithProject
   => ExistingProject
   -> t m ("welcome" .== Window (t m) (Event WelcomeScreenMode)) Empty ()
 toTimelineWithProject project = do
-  let model = TimelineModel project initialFocus Nothing (ZoomLevel 1)
+  let model = TimelineModel project initialFocus Nothing (ZoomLevel 1) Nothing
   destroyWindow #welcome
   newWindow
     #timeline

--- a/src/Komposition/Composition.hs
+++ b/src/Komposition/Composition.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeFamilies          #-}
 module Komposition.Composition where
 
@@ -42,7 +41,7 @@ instance HasDuration (AudioPart a) where
     AudioClip _ a -> durationOf a
     AudioGap _ d -> d
 
-data Timeline a =
+newtype Timeline a =
   Timeline (NonEmpty (Sequence a))
   deriving (Eq, Show, Functor, Generic)
 
@@ -69,3 +68,10 @@ instance HasDuration (Parallel a) where
 
 emptyTimeline :: Timeline ()
 emptyTimeline = Timeline (Sequence () (Parallel () [] [] :| []) :| [])
+
+data SomeComposition a
+  = SomeSequence (Sequence a)
+  | SomeParallel (Parallel a)
+  | SomeVideoPart (CompositionPart Video a)
+  | SomeAudioPart (CompositionPart Audio a)
+  deriving (Show, Eq)

--- a/src/Komposition/Composition/Delete.hs
+++ b/src/Komposition/Composition/Delete.hs
@@ -9,60 +9,72 @@ module Komposition.Composition.Delete where
 import           Komposition.Prelude
 
 import           Control.Lens
-import qualified Data.List            as List
-import qualified Data.List.NonEmpty   as NonEmpty
+import qualified Data.List                     as List
+import qualified Data.List.NonEmpty            as NonEmpty
 
 import           Komposition.Composition
 import           Komposition.Focus
 import           Komposition.Focus.Parent
 
-deleteAt :: (Int -> t a -> ([a], [a])) -> Int -> t a -> [a]
-deleteAt splitAt' i xs =
-  let (before, after) = splitAt' i xs
-  in before <> drop 1 after
-
 -- | Delete a composition or part in the 'Timeline', at the 'Focus',
 -- returning a new 'Timeline' if the focus is valid, and possibly a
 -- 'FocusCommand' required to obtain a new valid focus into the new
 -- 'Timeline'.
-delete ::
-     Focus (ToFocusType Timeline)
-  -> Timeline a
-  -> Maybe (Timeline a, Maybe FocusCommand)
-delete focus comp = runStateT (withParentOf traversal focus comp) Nothing
+delete :: Focus (ToFocusType Timeline) -> Timeline a -> Maybe (DeletionResult a)
+delete focus comp = do
+  (tl, st ) <- runStateT (withParentOf traversal focus comp) Nothing
+  (sc, cmd) <- st
+  pure (DeletionResult tl sc cmd)
   where
-    traversal =
-      ParentTraversal
-      { onTimeline =
-          \i (Timeline children') -> do
-            moveIfAtEnd children' i
-            maybe mzero (pure . Timeline) $
-              NonEmpty.nonEmpty (deleteAt NonEmpty.splitAt i children')
-      , onSequence =
-        \i (Sequence ann children') -> do
-            moveIfAtEnd children' i
-            maybe mzero (pure . Sequence ann) $
-              NonEmpty.nonEmpty (deleteAt NonEmpty.splitAt i children')
-      , onVideoParts = \i vs -> moveIfAtEnd vs i *> pure (deleteAt List.splitAt i vs)
-      , onAudioParts = \i as -> moveIfAtEnd as i *> pure (deleteAt List.splitAt i as)
+    traversal = ParentTraversal
+      { onTimeline   = \i (Timeline children') -> do
+        (deleted, remaining) <- lift (deleteAt NonEmpty.splitAt i children')
+        put (Just (SomeSequence deleted, commandIfAtEnd children' i))
+        maybe mzero (pure . Timeline) (NonEmpty.nonEmpty remaining)
+      , onSequence   = \i (Sequence ann children') -> do
+        (deleted, remaining) <- lift (deleteAt NonEmpty.splitAt i children')
+        put (Just (SomeParallel deleted, commandIfAtEnd children' i))
+        maybe mzero (pure . Sequence ann) (NonEmpty.nonEmpty remaining)
+      , onVideoParts = \i vs -> do
+        (deleted, remaining) <- lift (deleteAt List.splitAt i vs)
+        put (Just (SomeVideoPart deleted, commandIfAtEnd vs i))
+        pure remaining
+      , onAudioParts = \i as -> do
+        (deleted, remaining) <- lift (deleteAt List.splitAt i as)
+        put (Just (SomeAudioPart deleted, commandIfAtEnd as i))
+        pure remaining
       }
-    moveIfAtEnd :: Foldable t => t a -> Int -> StateT (Maybe FocusCommand) Maybe ()
-    moveIfAtEnd (length -> 1) _ = put (Just FocusUp)
-    moveIfAtEnd (pred . length -> maxIndex) idx
-      | idx >= maxIndex = put (Just FocusLeft)
-      | otherwise = pure ()
+    commandIfAtEnd :: Foldable t => t a -> Int -> Maybe FocusCommand
+    commandIfAtEnd (length -> 1) _ = pure FocusUp
+    commandIfAtEnd (pred . length -> maxIndex) idx
+      | idx >= maxIndex = pure FocusLeft
+      | otherwise       = mzero
 
 -- | Same as 'delete', but trying to apply the returned focus command.
-delete_ ::
-     ft ~ ToFocusType Timeline
+delete_
+  :: ft ~ ToFocusType Timeline
   => Focus ft
   -> Timeline a
   -> Either (FocusCommand, FocusError) (Timeline a, Focus ft)
-delete_ f s =
-  case delete f s of
-    Nothing -> pure (s, f)
-    Just (s', Nothing) -> pure (s', f)
-    Just (s', Just cmd) ->
-      modifyFocus s cmd f
-      & _Left %~ (cmd,)
-      <&> (s',)
+delete_ f s = case delete f s of
+  Nothing -> pure (s, f)
+  Just r  -> case adjustingFocusCommand r of
+    Nothing -> pure (resultingTimeline r, f)
+    Just cmd ->
+      modifyFocus s cmd f & _Left %~ (cmd, ) <&> (resultingTimeline r, )
+
+-- | In case a deletion was successful, this data type describes what
+-- the resulting timeline is, what in the composition was deleted, and
+-- a possible focus command that needs to be applied in order to keep
+-- the focus consistent with regards to the new timeline.
+data DeletionResult a =
+  DeletionResult
+  { resultingTimeline :: Timeline a
+  , deletedComposition :: SomeComposition a
+  , adjustingFocusCommand :: Maybe FocusCommand
+  }
+
+deleteAt :: (Int -> t a -> ([a], [a])) -> Int -> t a -> Maybe (a, [a])
+deleteAt splitAt' i xs = case splitAt' i xs of
+  (before, a : as) -> pure (a, before <> as)
+  (_     , []    ) -> mzero

--- a/src/Komposition/Composition/Paste.hs
+++ b/src/Komposition/Composition/Paste.hs
@@ -1,0 +1,36 @@
+-- | Transform a timeline by pasting something from the clipboard.
+
+module Komposition.Composition.Paste where
+
+import           Komposition.Prelude
+
+import           Komposition.Composition
+import           Komposition.Composition.Insert
+import           Komposition.Focus
+import           Komposition.MediaType
+
+data PastePosition
+  = PasteLeftOf
+  | PasteRightOf
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+  -- NOTE: Implemented in terms of the "Insert" module.
+
+-- | Pastes the clipboard 'SomeComposition' into the
+-- timeline.
+paste
+  :: Focus (ToFocusType Timeline)
+  -> SomeComposition a
+  -> PastePosition
+  -> Timeline a
+  -> Maybe (Timeline a)
+paste focus clipboard position = insert focus insertion insertPos
+  where
+    insertPos = case position of
+      PasteLeftOf  -> LeftOf
+      PasteRightOf -> RightOf
+    insertion = case clipboard of
+      SomeSequence  s -> InsertSequence s
+      SomeParallel  s -> InsertParallel s
+      SomeVideoPart s -> InsertVideoParts [s]
+      SomeAudioPart s -> InsertAudioParts [s]

--- a/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
@@ -13,34 +13,37 @@ module Komposition.UserInterface.GtkInterface.TimelineView
   )
 where
 
-import           Komposition.Prelude                                     hiding
-                                                                          (on)
+import           Komposition.Prelude     hiding ( on )
 
 import           Control.Lens
-import           Data.Int                                                (Int32)
-import           Data.Text                                               (Text)
-import           GI.Gtk                                                  (Align (..),
-                                                                          Box (..),
-                                                                          Button (..),
-                                                                          Label (..),
-                                                                          MenuBar (..),
-                                                                          MenuItem (..),
-                                                                          Orientation (..),
-                                                                          PolicyType (..),
-                                                                          ScrolledWindow (..),
-                                                                          Window (..))
+import           Data.Int                       ( Int32 )
+import           Data.Text                      ( Text )
+import           GI.Gtk                         ( Align(..)
+                                                , Box(..)
+                                                , Button(..)
+                                                , Label(..)
+                                                , MenuBar(..)
+                                                , MenuItem(..)
+                                                , Orientation(..)
+                                                , PolicyType(..)
+                                                , ScrolledWindow(..)
+                                                , Window(..)
+                                                )
 import           GI.Gtk.Declarative
-import           GI.Pango                                                (EllipsizeMode (..))
+import           GI.Pango                       ( EllipsizeMode(..) )
 
 import           Komposition.Composition
+import           Komposition.Composition.Paste  ( PastePosition(..) )
 import           Komposition.Composition.Focused
 import           Komposition.Duration
 import           Komposition.Focus
 import           Komposition.Library
 import           Komposition.MediaType
 import           Komposition.Project
-import           Komposition.UserInterface                               hiding (Window,
-                                                                          timelineView)
+import           Komposition.UserInterface
+                                         hiding ( Window
+                                                , timelineView
+                                                )
 import           Komposition.UserInterface.GtkInterface.RangeSlider
 import           Komposition.UserInterface.GtkInterface.ThumbnailPreview
 
@@ -192,6 +195,10 @@ renderMenu = container MenuBar [] $ do
     labelledItem Render
     labelledItem Exit
   subMenu "Timeline" $ do
+    labelledItem Copy
+    subMenu "Paste" $ do
+      labelledItem (Paste PasteRightOf)
+      labelledItem (Paste PasteLeftOf)
     insertSubMenu Video
     insertSubMenu Audio
     labelledItem Split

--- a/test/Komposition/Composition/DeleteTest.hs
+++ b/test/Komposition/Composition/DeleteTest.hs
@@ -15,16 +15,12 @@ import           Komposition.MediaType
 
 import           Komposition.TestLibrary
 
-spec_delete =
-  it "deletes only audio part and retains valid focus" $ do
-    let focus = SequenceFocus 0 (Just (ParallelFocus 0 (Just (ClipFocus Audio 0))))
-        before' =
-          Timeline
-            (pure (Sequence () (pure (Parallel () [] [audio1s]))))
-        focus' = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
-        after' =
-          Timeline
-            (pure (Sequence () (pure (Parallel () [] []))))
-    delete_ focus before' `shouldBe` Right (after', focus')
+spec_delete = it "deletes only audio part and retains valid focus" $ do
+  let focus =
+        SequenceFocus 0 (Just (ParallelFocus 0 (Just (ClipFocus Audio 0))))
+      before' = Timeline (pure (Sequence () (pure (Parallel () [] [audio1s]))))
+      focus'  = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
+      after'  = Timeline (pure (Sequence () (pure (Parallel () [] []))))
+  delete_ focus before' `shouldBe` Right (after', focus')
 
 {-# ANN module ("HLint: ignore Use camelCase" :: Prelude.String) #-}

--- a/test/Komposition/Composition/ValidFocusTest.hs
+++ b/test/Komposition/Composition/ValidFocusTest.hs
@@ -12,8 +12,9 @@ import           Komposition.Prelude
 import qualified Prelude
 
 import           Control.Lens
-import           Hedgehog                           hiding (Parallel)
-import qualified Hedgehog.Gen                       as Gen hiding (parallel)
+import           Hedgehog                hiding ( Parallel )
+import qualified Hedgehog.Gen                  as Gen
+                                         hiding ( parallel )
 import           Hedgehog.Range
 
 import           Komposition.Composition
@@ -28,7 +29,8 @@ import           Komposition.MediaType
 import           Komposition.Project
 import           Komposition.VideoSettings
 
-import qualified Komposition.Composition.Generators as Gen
+import qualified Komposition.Composition.Generators
+                                               as Gen
 
 data TestCommand
   = TestChangeFocus FocusCommand
@@ -154,13 +156,13 @@ applyTestCommand focus ep = \case
       (tl, focus') <- f (currentProject ep ^. timeline)
       return (ep & projectHistory %~ edit (set timeline tl), focus')
     handleDeleteResult initialFocus tl = \case
-      Nothing              -> failure
-      Just (tl', Just cmd) -> do
+      Nothing -> failure
+      Just (DeletionResult tl' _ (Just cmd)) -> do
         focus' <- either (\e -> footnoteShow e >> failure)
                          pure
                          (modifyFocus tl cmd initialFocus)
         pure (tl', focus')
-      Just (tl', Nothing) -> pure (tl', initialFocus)
+      Just (DeletionResult tl' _ Nothing) -> pure (tl', initialFocus)
 
 generateAndApplyTestCommands
   :: Monad m

--- a/test/Komposition/Composition/ValidFocusTest.hs
+++ b/test/Komposition/Composition/ValidFocusTest.hs
@@ -50,12 +50,12 @@ changeFocusCommand
   -> m TestCommand
 changeFocusCommand p focus =
   case atFocus focus (currentProject p ^. timeline) of
-    Just FocusedSequence{} ->
+    Just SomeSequence{} ->
       Gen.element (TestChangeFocus <$> [FocusDown, FocusLeft, FocusRight])
-    Just FocusedParallel{}  -> TestChangeFocus <$> Gen.enumBounded
-    Just FocusedVideoPart{} -> Gen.element
+    Just SomeParallel{}  -> TestChangeFocus <$> Gen.enumBounded
+    Just SomeVideoPart{} -> Gen.element
       (TestChangeFocus <$> [FocusUp, FocusDown, FocusLeft, FocusRight])
-    Just FocusedAudioPart{} ->
+    Just SomeAudioPart{} ->
       Gen.element (TestChangeFocus <$> [FocusUp, FocusLeft, FocusRight])
     Nothing -> Gen.discard
 

--- a/test/Komposition/FocusTest.hs
+++ b/test/Komposition/FocusTest.hs
@@ -15,78 +15,86 @@ import           Komposition.MediaType
 import           Komposition.TestLibrary
 
 spec_atFocus = do
-  it "returns focused sequence" $
-    atFocus (SequenceFocus 0 Nothing) timelineTwoParallels `shouldBe`
-    Just (FocusedSequence seqWithTwoParallels)
-  it "returns focused parallel" $
-    atFocus
-      (SequenceFocus 0 (Just (ParallelFocus 1 Nothing)))
-      timelineTwoParallels `shouldBe`
-    Just (FocusedParallel parallel2)
-  it "returns focused video clip" $
-    atFocus
-      (SequenceFocus 0 (Just (ParallelFocus 1 (Just (ClipFocus Video 0)))))
-      timelineTwoParallels `shouldBe`
-    Just (FocusedVideoPart videoGap3s)
-  it "returns focused audio clip" $
-    atFocus
-      (SequenceFocus 0 (Just (ParallelFocus 1 (Just (ClipFocus Audio 1)))))
-      timelineTwoParallels `shouldBe`
-    Just (FocusedAudioPart audio10s)
+  it "returns focused sequence"
+    $          atFocus (SequenceFocus 0 Nothing) timelineTwoParallels
+    `shouldBe` Just (SomeSequence seqWithTwoParallels)
+  it "returns focused parallel"
+    $          atFocus (SequenceFocus 0 (Just (ParallelFocus 1 Nothing)))
+                       timelineTwoParallels
+    `shouldBe` Just (SomeParallel parallel2)
+  it "returns focused video clip"
+    $          atFocus
+                 (SequenceFocus 0 (Just (ParallelFocus 1 (Just (ClipFocus Video 0)))))
+                 timelineTwoParallels
+    `shouldBe` Just (SomeVideoPart videoGap3s)
+  it "returns focused audio clip"
+    $          atFocus
+                 (SequenceFocus 0 (Just (ParallelFocus 1 (Just (ClipFocus Audio 1)))))
+                 timelineTwoParallels
+    `shouldBe` Just (SomeAudioPart audio10s)
 
 spec_modifyFocus = do
   it "moves the focus left within a sequence" $ do
     let before' = ParallelFocus 1 Nothing
-        after' = ParallelFocus 0 Nothing
+        after'  = ParallelFocus 0 Nothing
     modifyFocus seqWithTwoParallels FocusLeft before' `shouldBe` pure after'
   it "maintains sequence focus when left move is out of bounds" $ do
     let before' = ParallelFocus 0 Nothing
-    modifyFocus seqWithTwoParallels FocusLeft before' `shouldBe`
-      Left OutOfBounds
+    modifyFocus seqWithTwoParallels FocusLeft before'
+      `shouldBe` Left OutOfBounds
   it "maintains sequence focus when right move is out of bounds" $ do
     let before' = ParallelFocus 1 Nothing
-    modifyFocus seqWithTwoParallels FocusRight before' `shouldBe`
-      Left OutOfBounds
+    modifyFocus seqWithTwoParallels FocusRight before'
+      `shouldBe` Left OutOfBounds
   it "moves the focus left within parallel" $ do
     let before' = SequenceFocus 0 (Just (ParallelFocus 1 Nothing))
-        after' = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
+        after'  = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
     modifyFocus timelineTwoParallels FocusLeft before' `shouldBe` pure after'
   it "maintains parallel focus when left move is out of bounds" $ do
     let before' = ParallelFocus 0 (Just (ClipFocus Video 0))
-    modifyFocus seqWithTwoParallels FocusLeft before' `shouldBe`
-      Left OutOfBounds
+    modifyFocus seqWithTwoParallels FocusLeft before'
+      `shouldBe` Left OutOfBounds
   it "maintains parallel focus when right move is out of bounds" $ do
     let before' = ParallelFocus 0 (Just (ClipFocus Video 1))
-    modifyFocus seqWithTwoParallels FocusRight before' `shouldBe`
-      Left OutOfBounds
+    modifyFocus seqWithTwoParallels FocusRight before'
+      `shouldBe` Left OutOfBounds
   it "moves the focus up from parallel up to sequence" $ do
     let before' = SequenceFocus 0 (Just (ParallelFocus 1 Nothing))
-        after' = SequenceFocus 0 Nothing
+        after'  = SequenceFocus 0 Nothing
     modifyFocus timelineTwoParallels FocusUp before' `shouldBe` pure after'
   it "moves the focus up from video in multi-level sequence" $ do
     let before' =
           SequenceFocus 0 (Just (ParallelFocus 1 (Just (ClipFocus Video 1))))
         after' = SequenceFocus 0 (Just (ParallelFocus 1 Nothing))
     modifyFocus timelineTwoParallels FocusUp before' `shouldBe` pure after'
-  it "moves the focus up from audio into video with nearest start to the left" $ do
-    let sequence' =
-          Sequence () (pure (Parallel () [videoGap3s, video4s] [audioGap1s, audioGap3s, audio1s]))
-        before' = ParallelFocus 0 (Just (ClipFocus Audio 2))
-        after' = ParallelFocus 0 (Just (ClipFocus Video 1))
-    modifyFocus sequence' FocusUp before' `shouldBe` pure after'
+  it "moves the focus up from audio into video with nearest start to the left"
+    $ do
+        let
+          sequence' = Sequence
+            ()
+            (pure
+              (Parallel ()
+                        [videoGap3s, video4s]
+                        [audioGap1s, audioGap3s, audio1s]
+              )
+            )
+          before' = ParallelFocus 0 (Just (ClipFocus Audio 2))
+          after'  = ParallelFocus 0 (Just (ClipFocus Video 1))
+        modifyFocus sequence' FocusUp before' `shouldBe` pure after'
   it "moves the focus up from audio into video with same starting point" $ do
-    let sequence' =
-          Sequence () (pure (Parallel () [videoGap3s, video10s] [audioGap3s, audio10s]))
+    let sequence' = Sequence
+          ()
+          (pure (Parallel () [videoGap3s, video10s] [audioGap3s, audio10s]))
         before' = ParallelFocus 0 (Just (ClipFocus Audio 1))
-        after' = ParallelFocus 0 (Just (ClipFocus Video 1))
+        after'  = ParallelFocus 0 (Just (ClipFocus Video 1))
     modifyFocus sequence' FocusUp before' `shouldBe` pure after'
   it "maintains top sequence focus when trying to move up" $ do
     let before' = SequenceFocus 0 Nothing
-    modifyFocus timelineTwoParallels FocusUp before' `shouldBe`
-      Left CannotMoveUp
+    modifyFocus timelineTwoParallels FocusUp before'
+      `shouldBe` Left CannotMoveUp
   it "moves the focus down from sequence to a parallel" $ do
     let before' = SequenceFocus 0 Nothing
-        after' = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
+        after'  = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
     modifyFocus timelineTwoParallels FocusDown before' `shouldBe` pure after'
   it "moves the focus down from parallel to first video clip" $ do
     let before' = SequenceFocus 0 (Just (ParallelFocus 0 Nothing))
@@ -95,23 +103,32 @@ spec_modifyFocus = do
     modifyFocus timelineTwoParallels FocusDown before' `shouldBe` pure after'
   it "moves the focus down from video into audio in parallel" $ do
     let before' = ParallelFocus 0 (Just (ClipFocus Video 0))
-        after' = ParallelFocus 0 (Just (ClipFocus Audio 0))
+        after'  = ParallelFocus 0 (Just (ClipFocus Audio 0))
     modifyFocus seqWithTwoParallels FocusDown before' `shouldBe` pure after'
   it "cannot the focus down from audio" $ do
     let before' = ParallelFocus 0 (Just (ClipFocus Audio 0))
-    modifyFocus seqWithTwoParallels FocusDown before' `shouldBe`
-      Left CannotMoveDown
-  it "moves the focus down from video into audio with nearest start to the left" $ do
-    let sequence' =
-          Sequence () (pure (Parallel () [videoGap3s, video4s] [audioGap1s, audioGap3s, audio1s]))
-        before' = ParallelFocus 0 (Just (ClipFocus Video 1))
-        after' = ParallelFocus 0 (Just (ClipFocus Audio 1))
-    modifyFocus sequence' FocusDown before' `shouldBe` pure after'
+    modifyFocus seqWithTwoParallels FocusDown before'
+      `shouldBe` Left CannotMoveDown
+  it "moves the focus down from video into audio with nearest start to the left"
+    $ do
+        let
+          sequence' = Sequence
+            ()
+            (pure
+              (Parallel ()
+                        [videoGap3s, video4s]
+                        [audioGap1s, audioGap3s, audio1s]
+              )
+            )
+          before' = ParallelFocus 0 (Just (ClipFocus Video 1))
+          after'  = ParallelFocus 0 (Just (ClipFocus Audio 1))
+        modifyFocus sequence' FocusDown before' `shouldBe` pure after'
   it "moves the focus up from audio into video with same starting point" $ do
-    let sequence' =
-          Sequence () (pure (Parallel () [videoGap3s, video10s] [audioGap3s, audio10s]))
+    let sequence' = Sequence
+          ()
+          (pure (Parallel () [videoGap3s, video10s] [audioGap3s, audio10s]))
         before' = ParallelFocus 0 (Just (ClipFocus Video 1))
-        after' = ParallelFocus 0 (Just (ClipFocus Audio 1))
+        after'  = ParallelFocus 0 (Just (ClipFocus Audio 1))
     modifyFocus sequence' FocusDown before' `shouldBe` pure after'
 
 {-# ANN module ("HLint: ignore Use camelCase" :: Prelude.String) #-}


### PR DESCRIPTION
This closes #22, and as it was closely related, it also closes #17.

*Make sure to describe (where applicable):*

- Copy (yank) and paste with a single clipboard (register in Vim)
- Delete also puts the deleted composition part in the clipboard
- This changes some functionality by:
    - removing the leftmost/rightmost bindings
    - using <kbd>a</kbd>/<kbd>A</kbd> for add after/before, i.e. there are no longer separate bindings for _prepend_/_append_, only _add_ before or after
- Tests are adapted, but not covered by property based test for valid focus

**Checklist:**

Please make sure to check the following items (that are applicable.)

- [x] Doesn't duplicate any existing PR
- [x] Automated tests added
- [x] Includes relevant user guide/documentation changes
