### PR TITLE
Update Installation docs for osx

### DIFF
--- a/docs/src/user-guide/installation.md
+++ b/docs/src/user-guide/installation.md
@@ -83,7 +83,7 @@ komposition
 ## macOS
 
 ```shell
-brew install pkg-config gobject-introspection gtk+3 ffmpeg sox gstreamer  gst-plugins-base gst-libav
+brew install pkg-config gobject-introspection gtk+3 ffmpeg sox gstreamer libffi gst-plugins-base gst-libav
 brew install gst-plugins-good --with-gtk+3
 
 export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"


### PR DESCRIPTION
**Description:**

This pull requests fixes #70

*Make sure to describe (where applicable):*

- The docs for osx were missing `libffi` from the brew commands.

**Checklist:**

Please make sure to check the following items (that are applicable.)

- [x] Doesn't duplicate any existing PR
- [x] Includes relevant user guide/documentation changes
