### PR TITLE
Make proxy media filenames content-adressable

### DIFF
--- a/komposition.cabal
+++ b/komposition.cabal
@@ -50,6 +50,7 @@ library
                       , Komposition.History
                       , Komposition.Import.Audio
                       , Komposition.Import.Audio.Sox
+                      , Komposition.Import.Hash
                       , Komposition.Import.Video
                       , Komposition.Import.Video.FFmpeg
                       , Komposition.KeyMap
@@ -89,6 +90,8 @@ library
   build-depends:        base >=4.10 && <5
                       , async
                       , binary
+                      , bytestring
+                      , cryptonite
                       , deepseq
                       , directory
                       , exceptions

--- a/src/Komposition/Import/Hash.hs
+++ b/src/Komposition/Import/Hash.hs
@@ -1,0 +1,23 @@
+module Komposition.Import.Hash  where
+
+import           Komposition.Prelude
+
+import           Crypto.Hash as H
+import           Crypto.Random as R
+import qualified Data.ByteString.Lazy.Char8 as Lazy
+import qualified Data.ByteString.Char8      as C
+import           System.FilePath
+
+-- | create a hashed basename from source file
+createSHA1BaseName :: [Char] -> IO [Char]
+createSHA1BaseName filepath = do
+  rand <- makeHex
+  let name = takeBaseName filepath
+      lazyBs = Lazy.pack (name <> rand)
+  pure $ hex lazyBs
+
+hex :: Lazy.ByteString -> [Char]
+hex bs = show (H.hashlazy bs :: Digest SHA1)
+
+makeHex :: IO [Char]
+makeHex = C.unpack <$> R.getRandomBytes 10

--- a/src/Komposition/Import/Video/FFmpeg.hs
+++ b/src/Komposition/Import/Video/FFmpeg.hs
@@ -51,8 +51,8 @@ import           Data.Time.Clock
 import qualified Data.Vector                as V
 import qualified Data.Vector.Generic        as VG
 import           Graphics.ColorSpace        as A
-import           Pipes                      (Pipe, Producer, (>->))
 import qualified Pipes
+import           Pipes                      (Pipe, Producer, (>->))
 import qualified Pipes.Parse                as Pipes
 import qualified Pipes.Prelude              as Pipes hiding (show)
 import           Pipes.Safe
@@ -64,6 +64,7 @@ import           Komposition.Duration
 import           Komposition.FFmpeg.Command (Command (Command))
 import qualified Komposition.FFmpeg.Command as Command
 import           Komposition.FFmpeg.Process
+import           Komposition.Import.Hash    (createSHA1BaseName)
 import           Komposition.Import.Video
 import           Komposition.Library
 import           Komposition.Progress
@@ -315,8 +316,9 @@ transcode'
 transcode' videoSettings (view unOriginalPath -> sourceFile) fullLength outDir progressMsg
   = do
     liftIO (createDirectoryIfMissing True outDir)
+    shaBasename <- liftIO $ createSHA1BaseName sourceFile
     let
-      proxyPath = outDir </> takeBaseName sourceFile <> ".transcoded.mp4"
+      proxyPath = outDir </> shaBasename <> ".transcoded.mp4"
       cmd       = Command
         { output      = Command.FileOutput proxyPath
         , inputs      = pure (Command.FileSource sourceFile)


### PR DESCRIPTION
**Description:**

This pull requests fixes #24

*Make sure to describe (where applicable):*

- imported video proxy naming is a combination of an original filename and randomly generated SHA1
- *GUI changes, preferably with screenshots* none
- *Breaking changes* none
- *Changed dependencies, Haskell or system ones*
- *How it has been verified/tested* manually but technically `createSHA1BaseName` could be tested to make sure given the same file name different SHA's are created

**Checklist:**

Please make sure to check the following items (that are applicable.)

- [x] Doesn't duplicate any existing PR
- [ ] Automated tests added
- [ ] Includes relevant user guide/documentation changes

**How to test:**
import new video file and look at the command line output to see the naming of files should be as follows:
<img width="649" alt="screenshot 2019-01-08 at 20 12 00" src="https://user-images.githubusercontent.com/3036557/50856110-b206a680-1381-11e9-9836-67ea0b02bf67.png">


**TODO: Testing instructions for reviewer.**
I split this functionality out into its own file as I was unsure where it could live. This is because the function could also be used with #72 
