### PR TITLE
Make Gap duration adjustable - WIP

### DIFF
--- a/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
+++ b/src/Komposition/UserInterface/GtkInterface/TimelineView.hs
@@ -203,6 +203,18 @@ durationControl vs range' current = toDuration <$> numberInput NumberInputProper
   }
   where toDuration (NumberInputChanged n) = durationFromSeconds n
 
+gapDurationControl :: VideoSettings -> Duration -> BoxChild (Event TimelineMode)
+gapDurationControl vs d = container
+  Box
+  [#orientation := OrientationHorizontal]
+  [ BoxChild defaultBoxChildProperties { expand  = True
+                                       , fill    = True
+                                       , padding = 5
+                                       }
+  $   FocusedClipStartSet
+  <$> durationControl vs (0, d) d
+  ]
+
 clipSpanControl :: VideoSettings -> VideoAsset -> TimeSpan -> BoxChild (Event TimelineMode)
 clipSpanControl vs asset ts = container
   Box
@@ -256,7 +268,10 @@ renderSidebar vs mcomp = pane defaultPaneProperties $ container
              (formatDuration (asset ^. videoAssetMetadata . duration))
            ]
       Just (SomeVideoPart (VideoGap _ d)) ->
-        [heading "Video Gap", textEntry "Duration" (formatDuration d)]
+        [ heading "Video Gap"
+        , textEntry "Duration" (formatDuration d)
+        , gapDurationControl vs d
+        ]
       Just (SomeAudioPart (AudioClip _ asset)) ->
         [ heading "Audio Clip"
         , textEntry "Duration"


### PR DESCRIPTION
**Description:**

This pull requests fixes #69

*Make sure to describe (where applicable):*

- The ability to adjust the gap duration in the sidebar 

<img width="726" alt="screenshot 2019-01-08 at 22 13 59" src="https://user-images.githubusercontent.com/3036557/50862306-37df1d80-1393-11e9-9acb-adba3ca13740.png">

**Checklist:**

Please make sure to check the following items (that are applicable.)

- [x] Doesn't duplicate any existing PR
- [ ] Automated tests added
- [ ] Includes relevant user guide/documentation changes

**How to test:**
add video gap, select gap and on the sidebar adjust it's duration.

**TODO: Testing instructions for reviewer.**
