### PR TITLE
Better classifier tests

### DIFF
--- a/test/Komposition/Import/Video/FFmpegTest.hs
+++ b/test/Komposition/Import/Video/FFmpegTest.hs
@@ -133,11 +133,11 @@ genSegment segmentRange resolution =
   Gen.choice
   [genScene segmentRange resolution, genPause segmentRange resolution]
 
-genSegments :: MonadGen m => Range Int -> Range Int -> Ix2 -> m [TestSegment]
-genSegments numSegments segmentRange resolution = do
+genSegments :: MonadGen m => Range Int -> Range Int -> Range Int -> Ix2 -> m [TestSegment]
+genSegments numSegments sceneRange pauseRange resolution = do
   n <- Gen.int numSegments
-  pair <- genPair (genScene segmentRange resolution)
-                  (genPause segmentRange resolution)
+  pair <- genPair (genScene sceneRange resolution)
+                  (genPause pauseRange resolution)
   cycle pair & take n & pure
 
 addTimed :: [a] -> [Timed a]
@@ -179,12 +179,20 @@ assertStillLengthAtLeast t = \case
 testSegmentsToPixelFrames :: [TestSegment] -> [Timed MassivFrame]
 testSegmentsToPixelFrames = map (fmap toFrame) . addTimed . foldMap unwrapSegment
 
+frameCountDuration :: Int -> Double
+frameCountDuration n = (1 / fromIntegral frameRate) * fromIntegral n
+
 hprop_classifies_still_segments_of_min_length = withTests 100 . property $ do
-  minStillSegmentTime <- forAll $
-    Gen.double (Range.linearFrac (1 / fromIntegral frameRate) 2)
+  -- Generate a minimum still still segment duration used as a parameter in the
+  -- following steps
+  minStillSegmentFrames <- forAll $ Gen.int (Range.linear 2 (2 * frameRate))
+  let minStillSegmentTime = frameCountDuration minStillSegmentFrames
   -- Generate test segments
   segments <- forAll $ genSegments (Range.linear 1 10)
-                                   (Range.linear 1 (frameRate * 4))
+                                   (Range.linear 1
+                                                 (minStillSegmentFrames * 2))
+                                   (Range.linear minStillSegmentFrames
+                                                 (minStillSegmentFrames * 2))
                                    resolution
   -- Convert test segments to actual pixel frames
   let pixelFrames = testSegmentsToPixelFrames segments
@@ -218,11 +226,18 @@ movingSceneTimeSpans = snd . foldl' go (Duration 0, [])
         | otherwise -> pure ts { spanStart = spanStart ts - frameDuration }
       Pause _ -> mempty
 
-hprop_classifies_same_scenes_as_input = withShrinks 50 . withTests 100 . property $ do
+hprop_classifies_same_scenes_as_input = withShrinks 50 . property $ do
+  -- Generate a minimum still still segment duration used as a parameter in the
+  -- following steps
+  minStillSegmentFrames <- forAll $ Gen.int (Range.linear 2 (2 * frameRate))
+  let minStillSegmentTime = frameCountDuration minStillSegmentFrames
   -- Generate test segments
-  segments <- forAll $ do
-    let segmentLength = Range.linear (frameRate * 1) (frameRate * 5)
-    genSegments (Range.linear 0 10) segmentLength resolution
+  segments <- forAll $ genSegments (Range.linear 1 10)
+                                   (Range.linear 1
+                                                 (minStillSegmentFrames * 2))
+                                   (Range.linear minStillSegmentFrames
+                                                 (minStillSegmentFrames * 2))
+                                   resolution
   -- Convert test segments to timespanned ones, and actual pixel frames
   let durations = map segmentWithDuration segments
       pixelFrames = testSegmentsToPixelFrames segments
@@ -231,7 +246,7 @@ hprop_classifies_same_scenes_as_input = withShrinks 50 . withTests 100 . propert
 
   let classifiedFrames =
         Pipes.each pixelFrames
-        & classifyMovement 1.0
+        & classifyMovement minStillSegmentTime
         & Pipes.toList
 
   annotateShow (map (map time) classifiedFrames)
@@ -248,17 +263,24 @@ hprop_classifies_same_scenes_as_input = withShrinks 50 . withTests 100 . propert
 
   where resolution = 10 :. 10
 
-hprop_classifies_same_number_of_frames_as_input = withShrinks 50 . withTests 100 . property $ do
+hprop_classifies_same_number_of_frames_as_input = withShrinks 50 . property $ do
+  -- Generate a minimum still still segment duration used as a parameter in the
+  -- following steps
+  minStillSegmentFrames <- forAll $ Gen.int (Range.linear 1 (2 * frameRate))
+  let minStillSegmentTime = frameCountDuration minStillSegmentFrames
   -- Generate test segments
-  segments <- forAll $ do
-    let segmentLength = Range.linear (frameRate * 1) (frameRate * 5)
-    genSegments (Range.linear 0 10) segmentLength resolution
+  segments <- forAll $ genSegments (Range.linear 1 10)
+                                   (Range.linear 1
+                                                 (minStillSegmentFrames * 2))
+                                   (Range.linear minStillSegmentFrames
+                                                 (minStillSegmentFrames * 2))
+                                   resolution
   -- Convert test segments to timespanned ones, and actual pixel frames
   let pixelFrames = testSegmentsToPixelFrames segments
 
   let classifiedFrames =
         Pipes.each pixelFrames
-        & classifyMovement 0.8
+        & classifyMovement minStillSegmentTime
         & Pipes.toList
 
   length classifiedFrames === length pixelFrames


### PR DESCRIPTION
Also generates the minimum still segment duration in classifier tests, and uses separate ranges for moving and still segments.