### PR TITLE
Loosen bound on gi-gtk-declarative.

### DIFF
--- a/komposition.cabal
+++ b/komposition.cabal
@@ -104,7 +104,7 @@ library
                       , gi-glib
                       , gi-gst
                       , gi-gtk
-                      , gi-gtk-declarative >= 0.5 && < 0.6
+                      , gi-gtk-declarative >= 0.5 && < 0.7
                       , gi-gdk
                       , gi-gdkpixbuf
                       , gi-pango


### PR DESCRIPTION
This looser bound allows a newer version of gi-pango to be used (1.0.22), which contains an important bugfix that otherwise prevented me from compiling `komposition`.
