### PR TITLE
Actually link to install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ See [the documentation and user guide](https://owickstrom.github.io/komposition/
 ## Build Instructions
 
 This project can be built using Stack, Cabal, and Nix. Please see the
-[Installation docs](https://owickstrom.github.io/komposition/) for build
-instructions.
+[Installation
+docs](https://owickstrom.github.io/komposition/user-guide/installation/)
+for build instructions.
 
 ## License
 


### PR DESCRIPTION
The link the README linked to the website root, not the install guide.