### PR TITLE
Constrain protolude to <0.3

### DIFF
--- a/komposition.cabal
+++ b/komposition.cabal
@@ -123,7 +123,7 @@ library
                       , pipes-parse
                       , pipes-safe
                       , primitive
-                      , protolude
+                      , protolude >= 0.2.4 && < 0.3
                       , typed-process >= 0.2 && < 0.3
                       , row-types
                       , safe-exceptions


### PR DESCRIPTION
Hi, I'm working on updating ghc on [Homebrew](https://github.com/Homebrew/homebrew-core/pull/54005), and the formula for this was failing to build because protolude seems to have released a new version
This just clamps the bounds to the one compatible with this
